### PR TITLE
Expense types + savings-target rounding

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -17,14 +17,6 @@ Known limitations:
 - **`recommendedInvestment` on Assets is silently month-coupled** — it derives from `effectiveIncome` (month-scoped), so with the picker hidden on `/assets` the value still reflects whatever month was last selected on Budget/Dashboard. **Where**: `calcRecommendations(effectiveIncome, …)` at `src/context/FinanceContext.tsx:1654`, consumed in `src/pages/AssetPage.tsx`.
 - **Net-worth history editor covers a rolling 12-month window** matching the Dashboard chart. Editing months older than 12 back isn't exposed.
 
-## Dark old-money theme — follow-ups
-
-The `theme/dark-old-money` branch reskins the whole app (tokens in `src/index.css`, restyled `Card`/`Button`/`Layout`, donut/pie → allocation-strip/bar-list, serif headings, mono figures, ≤8px radii, no gradients/shadows, new favicon). Deferred / noticed items:
-
-- **Fonts load from Google Fonts CDN** (`index.html`) — Cormorant Garamond, IBM Plex Mono, Inter. The PWA is offline-capable but these aren't precached (the service worker globs js/css/html/svg/webmanifest only), so an offline install falls back to system fonts. To guarantee the brand type offline, self-host the woff2 files under `public/` and `@font-face` them in `src/index.css` (or add the font files to the PWA precache glob).
-- **Expense-category colours are hash-based, not semantic.** `FixedExpense` has no `type` field (`src/context/FinanceContext.tsx`), so `getCategoryColor` in `src/pages/BudgetPage.tsx` hashes the name into the restricted role palette. The reference mockup colours categories by *type* (Fast=teal, Variabel=forest, Abonnement=slate, Forsikring=rust). To match it, add an expense `type` field (data-model change — was intentionally not done without sign-off) and map type→role colour.
-- **Pre-existing (not theme): `savingsTargetPercent` renders as a long unrounded float** in a few spots (e.g. Dashboard "Sparemål" chip, Settings slider readout). It's set to a raw ratio in `handleSpendingEdit`/`handleInvestmentEdit` (`src/components/SmartRecommendations.tsx`). Round on write or on display.
-
 ## Live SSB wage statistics
 
 `/api/wage-stats` currently returns a curated static series (server/index.js, `WAGE_STATS_STATIC`). Should query SSB table 11418 (or 13606) for live national median annual wage instead.

--- a/src/components/SmartRecommendations.tsx
+++ b/src/components/SmartRecommendations.tsx
@@ -120,13 +120,13 @@ export default function SmartRecommendations() {
   const handleSpendingEdit = (newSpending: number) => {
     if (totalResidual <= 0) return;
     const clamped = Math.min(newSpending, totalResidual);
-    setSavingsTargetPercent(((totalResidual - clamped) / totalResidual) * 100);
+    setSavingsTargetPercent(Math.round(((totalResidual - clamped) / totalResidual) * 100));
   };
 
   const handleInvestmentEdit = (newInvest: number) => {
     if (totalResidual <= 0) return;
     const clamped = Math.min(newInvest, totalResidual);
-    setSavingsTargetPercent((clamped / totalResidual) * 100);
+    setSavingsTargetPercent(Math.round((clamped / totalResidual) * 100));
   };
 
   const totalSpentThisMonth = dailyData.reduce((s, d) => s + d.spent, 0);
@@ -191,7 +191,7 @@ export default function SmartRecommendations() {
             </div>
           ) : (
             <button onClick={() => setEditingPct(true)} className="flex items-center gap-1 group">
-              <span className="text-[13px] font-bold font-mono text-[var(--forest-light)]">{savingsTargetPercent}%</span>
+              <span className="text-[13px] font-bold font-mono text-[var(--forest-light)]">{Math.round(savingsTargetPercent)}%</span>
               <Edit2 size={11} className="text-[var(--text-2)] opacity-0 group-hover:opacity-100 transition-opacity" />
             </button>
           )}

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -22,10 +22,14 @@ import {
 
 // --- Types ---
 
+// Category of a fixed expense — drives its colour role in the budget charts.
+export type ExpenseType = 'fixed' | 'variable' | 'subscription' | 'insurance';
+
 export interface FixedExpense {
   id: string;
   name: string;
   amount: number;
+  type?: ExpenseType; // optional for back-compat with older stored/imported data
 }
 
 export interface DailyTransaction {
@@ -257,6 +261,8 @@ export const translations = {
     editIncome: 'Sett månedsinntekt:',
     newExpenseName: 'Navn på utgift:',
     newAmount: 'Beløp:',
+    expenseTypeLabel: 'Type:',
+    expenseType: { fixed: 'Fast', variable: 'Variabel', subscription: 'Abonnement', insurance: 'Forsikring' },
     editName: 'Nytt navn:',
     editAmount: 'Nytt beløp:',
     editDescription: 'Ny beskrivelse:',
@@ -709,6 +715,8 @@ export const translations = {
     editIncome: 'Set monthly income:',
     newExpenseName: 'Expense name:',
     newAmount: 'Amount:',
+    expenseTypeLabel: 'Type:',
+    expenseType: { fixed: 'Fixed', variable: 'Variable', subscription: 'Subscription', insurance: 'Insurance' },
     editName: 'New name:',
     editAmount: 'New amount:',
     editDescription: 'New description:',
@@ -1126,14 +1134,14 @@ export const translations = {
 };
 
 const DEFAULT_FIXED_EXPENSES: FixedExpense[] = [
-  { id: '1', name: 'Huslån',          amount: 12000 },
-  { id: '2', name: 'Felleskostnader', amount: 3000  },
-  { id: '3', name: 'Forsikring',      amount: 400   },
-  { id: '4', name: 'Strøm',           amount: 1000  },
-  { id: '5', name: 'Trening',         amount: 500   },
-  { id: '6', name: 'Mobil',           amount: 400   },
-  { id: '7', name: 'Mat',             amount: 5000  },
-  { id: '8', name: 'Sparing',         amount: 5000  },
+  { id: '1', name: 'Huslån',          amount: 12000, type: 'fixed'        },
+  { id: '2', name: 'Felleskostnader', amount: 3000,  type: 'fixed'        },
+  { id: '3', name: 'Forsikring',      amount: 400,   type: 'insurance'    },
+  { id: '4', name: 'Strøm',           amount: 1000,  type: 'fixed'        },
+  { id: '5', name: 'Trening',         amount: 500,   type: 'subscription' },
+  { id: '6', name: 'Mobil',           amount: 400,   type: 'subscription' },
+  { id: '7', name: 'Mat',             amount: 5000,  type: 'variable'     },
+  { id: '8', name: 'Sparing',         amount: 5000,  type: 'fixed'        },
 ];
 
 // Data-based default assumptions. These are the researched starting points users

--- a/src/lib/demoData.ts
+++ b/src/lib/demoData.ts
@@ -118,13 +118,13 @@ export function getDemoData(): Partial<ExportPayload> {
     savingsTargetPercent: 20,
 
     fixedExpenses: [
-      { id: 'demo-fx-1', name: 'Huslån', amount: 16500 },
-      { id: 'demo-fx-2', name: 'Felleskostnader', amount: 3400 },
-      { id: 'demo-fx-3', name: 'Strøm', amount: 1300 },
-      { id: 'demo-fx-4', name: 'Forsikring', amount: 650 },
-      { id: 'demo-fx-5', name: 'Mobil/Internett', amount: 800 },
-      { id: 'demo-fx-6', name: 'Trening', amount: 500 },
-      { id: 'demo-fx-7', name: 'Mat', amount: 6500 },
+      { id: 'demo-fx-1', name: 'Huslån', amount: 16500, type: 'fixed' },
+      { id: 'demo-fx-2', name: 'Felleskostnader', amount: 3400, type: 'fixed' },
+      { id: 'demo-fx-3', name: 'Strøm', amount: 1300, type: 'fixed' },
+      { id: 'demo-fx-4', name: 'Forsikring', amount: 650, type: 'insurance' },
+      { id: 'demo-fx-5', name: 'Mobil/Internett', amount: 800, type: 'subscription' },
+      { id: 'demo-fx-6', name: 'Trening', amount: 500, type: 'subscription' },
+      { id: 'demo-fx-7', name: 'Mat', amount: 6500, type: 'variable' },
     ],
 
     dailyTransactions: [

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -15,12 +15,13 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  Cell,
   LabelList,
   type TooltipContentProps,
 } from 'recharts';
 import { format, isSameMonth, startOfMonth } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
-import { useFinance, type TransactionTemplate } from '../context/FinanceContext';
+import { useFinance, type TransactionTemplate, type ExpenseType } from '../context/FinanceContext';
 import EditModal, { type ModalField } from '../components/EditModal';
 import ConfirmModal from '../components/ConfirmModal';
 
@@ -38,7 +39,15 @@ const CHART_COLORS = [
 const CHART_INK = '#9A9C8C';   // text-soft — axis labels
 const CHART_GRID = 'rgba(236,231,216,0.06)';
 const CHART_TRACK = 'rgba(236,231,216,0.05)';
-const TEAL = '#3F7373';
+
+// Fixed-expense type → role colour (matches the reference legend).
+const EXPENSE_TYPE_COLOR: Record<ExpenseType, string> = {
+  fixed: '#3F7373',        // teal — recurring/structural
+  variable: '#1F5A42',     // forest — variable spend
+  subscription: '#5B7280', // slate — subscriptions
+  insurance: '#B5533A',    // rust — insurance
+};
+const expenseColor = (type?: ExpenseType) => EXPENSE_TYPE_COLOR[type ?? 'fixed'];
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)] font-semibold';
@@ -107,17 +116,20 @@ const BudgetPage: React.FC = () => {
   };
 
   // --- Fixed Expenses ---
+  const typeOptions = (Object.keys(EXPENSE_TYPE_COLOR) as ExpenseType[]).map(v => ({ value: v, label: t.expenseType[v] }));
+
   const addFixedExpense = () => {
     openModal({
       title: t.fixedCosts,
       fields: [
         { key: 'name', label: t.newExpenseName, type: 'text', value: '', placeholder: 'Mat, Strøm...' },
         { key: 'amount', label: t.newAmount, type: 'number', value: '', placeholder: '0' },
+        { key: 'type', label: t.expenseTypeLabel, type: 'select', value: 'fixed', options: typeOptions },
       ],
       onSave: (vals) => {
         const amount = parsePositiveNumber(vals.amount);
         if (vals.name.trim() && amount !== null) {
-          setFixedExpenses([...fixedExpenses, { id: crypto.randomUUID(), name: vals.name.trim(), amount }]);
+          setFixedExpenses([...fixedExpenses, { id: crypto.randomUUID(), name: vals.name.trim(), amount, type: vals.type as ExpenseType }]);
           closeModal();
         } else {
           setModal(prev => prev ? { ...prev, error: !vals.name.trim() ? t.newExpenseName + ' er påkrevd' : t.newAmount + ' må være et positivt tall' } : null);
@@ -126,17 +138,18 @@ const BudgetPage: React.FC = () => {
     });
   };
 
-  const editFixedExpense = (id: string, name: string, amount: number) => {
+  const editFixedExpense = (id: string, name: string, amount: number, type?: ExpenseType) => {
     openModal({
       title: name,
       fields: [
         { key: 'name', label: t.editName, type: 'text', value: name },
         { key: 'amount', label: t.editAmount, type: 'number', value: amount.toString() },
+        { key: 'type', label: t.expenseTypeLabel, type: 'select', value: type ?? 'fixed', options: typeOptions },
       ],
       onSave: (vals) => {
         const newAmount = parsePositiveNumber(vals.amount);
         if (vals.name.trim() && newAmount !== null) {
-          setFixedExpenses(fixedExpenses.map(e => e.id === id ? { ...e, name: vals.name.trim(), amount: newAmount } : e));
+          setFixedExpenses(fixedExpenses.map(e => e.id === id ? { ...e, name: vals.name.trim(), amount: newAmount, type: vals.type as ExpenseType } : e));
           closeModal();
         } else {
           setModal(prev => prev ? { ...prev, error: !vals.name.trim() ? t.editName + ' er påkrevd' : t.editAmount + ' må være et positivt tall' } : null);
@@ -375,19 +388,28 @@ const BudgetPage: React.FC = () => {
               <PlusCircle size={18} strokeWidth={2} />
             </button>
           </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+            {(Object.keys(EXPENSE_TYPE_COLOR) as ExpenseType[]).map(ty => (
+              <span key={ty} className="flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--text-2)' }}>
+                <span className="w-[7px] h-[7px] rounded-[2px]" style={{ background: EXPENSE_TYPE_COLOR[ty] }} />
+                {t.expenseType[ty]}
+              </span>
+            ))}
+          </div>
           <div className="space-y-0">
             {fixedExpenses.map((expense) => (
               <div key={expense.id} className="flex items-center justify-between group py-3 border-b border-[var(--border)] last:border-0">
                 <span
-                  className="text-[13px] font-medium text-[var(--text-1)] cursor-pointer hover:text-[var(--accent)] transition-colors"
-                  onClick={() => editFixedExpense(expense.id, expense.name, expense.amount)}
+                  className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-1)] cursor-pointer hover:text-[var(--accent)] transition-colors min-w-0"
+                  onClick={() => editFixedExpense(expense.id, expense.name, expense.amount, expense.type)}
                 >
-                  {expense.name}
+                  <span className="w-[7px] h-[7px] rounded-[2px] shrink-0" style={{ background: expenseColor(expense.type) }} />
+                  <span className="truncate">{expense.name}</span>
                 </span>
                 <div className="flex items-center gap-3">
                   <span
                     className="text-[13px] font-mono font-medium text-[var(--text-1)] cursor-pointer hover:text-[var(--accent)] transition-colors"
-                    onClick={() => editFixedExpense(expense.id, expense.name, expense.amount)}
+                    onClick={() => editFixedExpense(expense.id, expense.name, expense.amount, expense.type)}
                   >
                     {formatCurrency(expense.amount)}
                   </span>
@@ -453,9 +475,11 @@ const BudgetPage: React.FC = () => {
                   dataKey="amount"
                   radius={[0, 3, 3, 0]}
                   barSize={12}
-                  fill={TEAL}
                   background={{ fill: CHART_TRACK, radius: 3 } as unknown as React.ComponentProps<typeof Bar>['background']}
                 >
+                  {sortedExpenses.map((e, i) => (
+                    <Cell key={`cell-${i}`} fill={expenseColor(e.type)} />
+                  ))}
                   <LabelList
                     dataKey="amount"
                     position="right"

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -608,10 +608,10 @@ const DashboardPage: React.FC = () => {
                 {formatCurrency(recommendedInvestment)}
               </div>
               <div className="text-[11px] mt-1" style={{ color: 'var(--text-3)' }}>
-                {lang === 'nb' ? `April · ${savingsTargetPercent}% mål nådd` : `${savingsTargetPercent}% target hit`}
+                {lang === 'nb' ? `April · ${Math.round(savingsTargetPercent)}% mål nådd` : `${Math.round(savingsTargetPercent)}% target hit`}
               </div>
             </div>
-            <DeltaChip tone="positive" size="sm">+{savingsTargetPercent}%</DeltaChip>
+            <DeltaChip tone="positive" size="sm">+{Math.round(savingsTargetPercent)}%</DeltaChip>
           </div>
 
           <MonthlyInvestmentBars bars={investmentBars} formatCurrency={formatCurrency} />

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -508,7 +508,7 @@ export default function SettingsPage() {
           <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
             <RangeRow
               label={t.settings.savingsTargetPct}
-              value={savingsTargetPercent}
+              value={Math.round(savingsTargetPercent)}
               onChange={setSavingsTargetPercent}
               min={0}
               max={95}


### PR DESCRIPTION
Three small follow-ups from the theme work.

## Fixed-expense types (data-model change)
- Added an optional `ExpenseType` (`fixed | variable | subscription | insurance`) to `FixedExpense`. Optional for back-compat — existing/imported rows with no type fall back to `fixed`. Default and demo data are seeded with types.
- Budget page now colours by type (teal / forest / slate / rust, matching the reference legend):
  - Fixed-expense list rows get a type swatch + a type legend
  - "Fordelingsanalyse" distribution bars are coloured per type
  - The add/edit-expense modal has a **Type** selector

## Savings-target rounding
- `savingsTargetPercent` could be stored/shown as a long float (e.g. `49.4939…%`). Now rounded at the source (the spending/investment edit handlers) and on display (Smart Recommendations, Dashboard, Settings slider), so pre-existing float values also render cleanly.

## Backlog
- Removed the resolved "Dark old-money theme — follow-ups" section: offline-font self-hosting dropped (not wanted), expense-type coloring and savings rounding done.

## Verified
- `tsc` clean; Docker build clean.
- Checked in demo mode: Forsikring→rust, Mobil/Trening→slate, Mat→forest, rest→teal, across legend, row swatches and bars. Savings target shows a whole number.