### PR TITLE
Plug-and-play defaults for easy self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ make build
 
 Open http://localhost:8080.
 
+That's the whole setup — **no config files, no environment variables required.** Your data persists in the `headroom_data` volume across restarts and image upgrades. The container fixes its own storage permissions on startup, so persistent storage works out of the box with a Docker volume, a bind mount, NFS, or a Kubernetes PVC.
+
+**Running it on a server / behind a reverse proxy?** Just change the port binding (`-p 8080:3001` for all interfaces, or map it into your proxy) — nothing else is needed. See [Security](#security) before exposing it beyond localhost.
+
 ## Commands
 
 | Command | Description |
@@ -70,6 +74,18 @@ To use it from another device:
 - Reach it over a private network (VPN, Tailscale, WireGuard).
 
 Only change the binding to `0.0.0.0` (all interfaces) if you understand that this exposes unauthenticated access to everyone on the network.
+
+**Optional hardening:** set `ALLOWED_HOSTS` (see [Configuration](#configuration)) to reject requests whose `Host` header isn't one you expect — a small guard against DNS-rebinding. It's off by default so the app works behind any hostname without configuration.
+
+## Configuration
+
+All optional — the defaults are sensible and nothing needs to be set.
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `DATA_DIR` | `/data` (in Docker) | Where the SQLite database is stored. |
+| `PORT` | `3001` | Port the server listens on inside the container. |
+| `ALLOWED_HOSTS` | _(unset — all hosts allowed)_ | Comma-separated hostname allowlist, e.g. `finance.example.com,localhost`. When unset, no host filtering is applied. |
 
 ## Data persistence
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,13 +1,28 @@
 #!/bin/sh
 set -e
 
-# The /data volume may pre-date the switch to a non-root runtime (older images
-# ran as root, so the volume and its database.sqlite are root-owned). Fix the
-# ownership while we still have root, then drop to the unprivileged `node` user
-# to run the app — so any RCE in the Node stack lands as `node`, not root.
+# DATA_DIR must be writable by the runtime user — SQLite fails hard (CANTOPEN)
+# otherwise. Ensure it exists first (harmless if the volume already has it).
+DATA_DIR="${DATA_DIR:-/data}"
+mkdir -p "$DATA_DIR" 2>/dev/null || true
+
 if [ "$(id -u)" = "0" ]; then
-  chown -R node:node /data 2>/dev/null || true
-  exec su-exec node:node "$@"
+  # Running as root: the /data volume may be root-owned (older images ran as
+  # root) or a bind mount. Fix ownership, then drop to the unprivileged `node`
+  # user — but ONLY if `node` can actually write there. On some hosts (certain
+  # bind mounts, userns-remap, rootless) the chown can't take effect; in that
+  # case stay root so the app still runs instead of crashing with CANTOPEN.
+  chown -R node:node "$DATA_DIR" 2>/dev/null || true
+  if su-exec node:node sh -c "test -w \"$DATA_DIR\""; then
+    exec su-exec node:node "$@"
+  fi
+  echo "[entrypoint] WARN: '$DATA_DIR' not writable by user 'node' after chown; running as root." >&2
+  exec "$@"
 fi
 
+# Started as a non-root user (e.g. compose 'user:' or rootless). We can't chown;
+# just warn clearly if the volume isn't writable, then hand off.
+if [ ! -w "$DATA_DIR" ]; then
+  echo "[entrypoint] ERROR: '$DATA_DIR' is not writable by uid $(id -u). Fix the volume ownership (chown it to this uid) or run the container as root." >&2
+fi
 exec "$@"

--- a/server/index.js
+++ b/server/index.js
@@ -36,19 +36,21 @@ app.use(helmet({
   crossOriginEmbedderPolicy: false,
 }));
 
-// Reject requests whose Host header isn't in the allowlist. Guards the
-// unauthenticated loopback service against DNS-rebinding (an attacker page on a
-// domain that resolves to 127.0.0.1). Reverse-proxy users set ALLOWED_HOSTS to
-// their external hostname(s).
-const ALLOWED_HOSTS = (process.env.ALLOWED_HOSTS || 'localhost,127.0.0.1,[::1]')
+// Optional Host-header allowlist (a DNS-rebinding guard). OFF by default so the
+// app works behind any hostname / reverse proxy / ingress out of the box. To
+// enable it, set ALLOWED_HOSTS to a comma-separated list of the hostname(s) the
+// app is served on, e.g. ALLOWED_HOSTS=finance.example.com,localhost.
+const ALLOWED_HOSTS = (process.env.ALLOWED_HOSTS || '')
   .split(',').map(h => h.trim().toLowerCase()).filter(Boolean);
-app.use((req, res, next) => {
-  const host = (req.hostname || '').toLowerCase();
-  if (host && !ALLOWED_HOSTS.includes(host)) {
-    return res.status(403).json({ error: 'host not allowed' });
-  }
-  next();
-});
+if (ALLOWED_HOSTS.length > 0) {
+  app.use((req, res, next) => {
+    const host = (req.hostname || '').toLowerCase();
+    if (host && !ALLOWED_HOSTS.includes(host)) {
+      return res.status(403).json({ error: 'host not allowed' });
+    }
+    next();
+  });
+}
 
 // The whole dataset is a single JSON blob that grows as transactions/snapshots
 // accumulate. Keep the limit generous so a large history doesn't start silently

--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,19 @@ if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
 
-const db = new Database(path.join(DATA_DIR, 'database.sqlite'));
+const DB_PATH = path.join(DATA_DIR, 'database.sqlite');
+let db;
+try {
+  db = new Database(DB_PATH);
+} catch (err) {
+  // Almost always a permissions problem: the data volume isn't writable by the
+  // container user. Fail with a clear, actionable message instead of a raw
+  // SQLITE_CANTOPEN stack trace.
+  console.error(`[db] Could not open ${DB_PATH}: ${err.message}`);
+  console.error(`[db] Ensure DATA_DIR (${DATA_DIR}) is writable by uid ${process.getuid ? process.getuid() : '?'}. ` +
+    `For Docker, either let the container start as root (it drops to 'node' after fixing perms) or chown the volume to that user.`);
+  process.exit(1);
+}
 
 db.exec(`
   CREATE TABLE IF NOT EXISTS finance_data (


### PR DESCRIPTION
Goal: anyone should get the container up with persistent storage, zero config.

The security hardening from the audit made self-hosting need several flags. This restores plug-and-play defaults:

- **Host-header allowlist is now opt-in.** Off unless `ALLOWED_HOSTS` is set, so the app works behind any hostname / reverse proxy / ingress out of the box (previously it returned `403 "host not allowed"` for anything but localhost). Set `ALLOWED_HOSTS` to enable the DNS-rebinding guard.
- **Recovers the entrypoint storage fix** (was authored but didn't land in the merge of #6): drops to non-root `node` only when it can write the volume, otherwise runs as root — so persistent storage works on a Docker volume, bind mount, NFS, or a K8s PVC without permission errors. Adds a clear startup message instead of a raw `SQLITE_CANTOPEN` stack trace.
- **README**: a "that's the whole setup" note, a Configuration table for the (all optional) `DATA_DIR` / `PORT` / `ALLOWED_HOSTS` env vars, and reverse-proxy guidance.

Verified: `tsc`/lint/tests pass; image builds; container runs non-root, accepts any Host with no env, writes and persists across restart; with `ALLOWED_HOSTS` set the guard enforces (allowed → 200, other → 403).

Follow-up: with the allowlist opt-in, the `ALLOWED_HOSTS` env in the homelab deployment (headroom PR #247) becomes optional — keep it for the guard, or drop it.