### PR TITLE
fix(docker): survive non-writable data volumes (NFS / K8s PVC)

### DIFF
--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -1,13 +1,28 @@
 #!/bin/sh
 set -e
 
-# The /data volume may pre-date the switch to a non-root runtime (older images
-# ran as root, so the volume and its database.sqlite are root-owned). Fix the
-# ownership while we still have root, then drop to the unprivileged `node` user
-# to run the app — so any RCE in the Node stack lands as `node`, not root.
+# DATA_DIR must be writable by the runtime user — SQLite fails hard (CANTOPEN)
+# otherwise. Ensure it exists first (harmless if the volume already has it).
+DATA_DIR="${DATA_DIR:-/data}"
+mkdir -p "$DATA_DIR" 2>/dev/null || true
+
 if [ "$(id -u)" = "0" ]; then
-  chown -R node:node /data 2>/dev/null || true
-  exec su-exec node:node "$@"
+  # Running as root: the /data volume may be root-owned (older images ran as
+  # root) or a bind mount. Fix ownership, then drop to the unprivileged `node`
+  # user — but ONLY if `node` can actually write there. On some hosts (certain
+  # bind mounts, userns-remap, rootless) the chown can't take effect; in that
+  # case stay root so the app still runs instead of crashing with CANTOPEN.
+  chown -R node:node "$DATA_DIR" 2>/dev/null || true
+  if su-exec node:node sh -c "test -w \"$DATA_DIR\""; then
+    exec su-exec node:node "$@"
+  fi
+  echo "[entrypoint] WARN: '$DATA_DIR' not writable by user 'node' after chown; running as root." >&2
+  exec "$@"
 fi
 
+# Started as a non-root user (e.g. compose 'user:' or rootless). We can't chown;
+# just warn clearly if the volume isn't writable, then hand off.
+if [ ! -w "$DATA_DIR" ]; then
+  echo "[entrypoint] ERROR: '$DATA_DIR' is not writable by uid $(id -u). Fix the volume ownership (chown it to this uid) or run the container as root." >&2
+fi
 exec "$@"

--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,19 @@ if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
 
-const db = new Database(path.join(DATA_DIR, 'database.sqlite'));
+const DB_PATH = path.join(DATA_DIR, 'database.sqlite');
+let db;
+try {
+  db = new Database(DB_PATH);
+} catch (err) {
+  // Almost always a permissions problem: the data volume isn't writable by the
+  // container user. Fail with a clear, actionable message instead of a raw
+  // SQLITE_CANTOPEN stack trace.
+  console.error(`[db] Could not open ${DB_PATH}: ${err.message}`);
+  console.error(`[db] Ensure DATA_DIR (${DATA_DIR}) is writable by uid ${process.getuid ? process.getuid() : '?'}. ` +
+    `For Docker, either let the container start as root (it drops to 'node' after fixing perms) or chown the volume to that user.`);
+  process.exit(1);
+}
 
 db.exec(`
   CREATE TABLE IF NOT EXISTS finance_data (


### PR DESCRIPTION
The entrypoint dropped to the non-root `node` user unconditionally. On volumes where the chown can't take effect (NFS exports, some bind mounts, userns), node then can't write /data and the server crashed with SQLITE_CANTOPEN on startup.

Now the entrypoint drops to `node` only if it can actually write DATA_DIR; otherwise it stays root (which the volume already permits — the pre-audit root-only image wrote fine there). The server also catches an open failure and prints a clear, actionable message instead of a raw stack trace.

Claude-Session: https://claude.ai/code/session_01KTnpECJguqTGBqdt9DDvb9