### PR TITLE
Chart colour sweep: shared axis/grid props, tokens instead of raw hex

### DIFF
--- a/src/components/BudgetDistributionChart.tsx
+++ b/src/components/BudgetDistributionChart.tsx
@@ -3,10 +3,7 @@ import {
   type TooltipContentProps,
 } from 'recharts';
 import type { FixedExpense } from '../context/FinanceContext';
-
-const CHART_INK = '#9A9C8C';   // text-soft — axis labels
-const CHART_GRID = 'rgba(236,231,216,0.06)';
-const CHART_TRACK = 'rgba(236,231,216,0.05)';
+import { CHART, GRID_PROPS } from '../lib/chartColors';
 
 interface Props {
   data: FixedExpense[];
@@ -28,18 +25,18 @@ export default function BudgetDistributionChart({
   return (
     <ResponsiveContainer width="100%" height="100%">
       <BarChart data={data} layout="vertical" margin={{ top: 4, right: 60, left: 16, bottom: 4 }}>
-        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke={CHART_GRID} />
+        <CartesianGrid {...GRID_PROPS} horizontal={false} />
         <XAxis type="number" hide />
         <YAxis
           dataKey="name"
           type="category"
           width={88}
-          tick={{ fontSize: 11, fill: CHART_INK, fontWeight: 500 }}
+          tick={{ fontSize: 11, fill: CHART.textSoft, fontWeight: 500 }}
           axisLine={false}
           tickLine={false}
         />
         <Tooltip
-          cursor={{ fill: CHART_TRACK }}
+          cursor={{ fill: CHART.track }}
           content={({ active, payload }: TooltipContentProps) => {
             if (!active || !payload?.length) return null;
             const d = payload[0].payload as { name: string; amount: number };
@@ -62,7 +59,7 @@ export default function BudgetDistributionChart({
           dataKey="amount"
           radius={[0, 3, 3, 0]}
           barSize={12}
-          background={{ fill: CHART_TRACK, radius: 3 } as unknown as React.ComponentProps<typeof Bar>['background']}
+          background={{ fill: CHART.track, radius: 3 } as unknown as React.ComponentProps<typeof Bar>['background']}
         >
           {data.map((e, i) => (
             <Cell key={`cell-${i}`} fill={expenseColor(e.type)} />
@@ -71,7 +68,7 @@ export default function BudgetDistributionChart({
             dataKey="amount"
             position="right"
             offset={10}
-            fill={CHART_INK}
+            fill={CHART.textSoft}
             fontSize={11}
             fontWeight={600}
             formatter={(v: unknown) => formatCurrencyShort(Number(v ?? 0))}

--- a/src/components/CategoryBreakdown.tsx
+++ b/src/components/CategoryBreakdown.tsx
@@ -3,6 +3,7 @@ import { format, subMonths } from 'date-fns';
 import { ChevronRight, TrendingUp, TrendingDown, Circle, Wallet } from 'lucide-react';
 import { useFinance, type DailyTransaction } from '../context/FinanceContext';
 import { categoryMeta, isCategoryKey } from '../lib/categories';
+import { CHART } from '../lib/chartColors';
 import { categoryMoM } from '../lib/categoryStats';
 import { txDisplayName } from '../lib/labelRules';
 import { DeltaChip } from './ui/DeltaChip';
@@ -26,7 +27,7 @@ export function CategoryBreakdown({ onEditTransaction }: { onEditTransaction?: (
   const total = rows.reduce((s, r) => s + r.current, 0);
 
   const label = (cat: string) => (isCategoryKey(cat) ? t.categoryLabels[cat] : cat);
-  const color = (cat: string) => categoryMeta(cat)?.color ?? '#5F6555';
+  const color = (cat: string) => categoryMeta(cat)?.color ?? CHART.textDim;
 
   const txForCategory = (cat: string) =>
     dailyTransactions

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -33,7 +33,7 @@ export default function ConfirmModal({
         className="w-full sm:w-auto sm:min-w-[340px] sm:max-w-sm bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 space-y-4 border border-[var(--border)]"
       >
         <div className="flex items-center gap-3">
-          {danger && <AlertTriangle size={18} className="text-[#B5533A] shrink-0" />}
+          {danger && <AlertTriangle size={18} className="text-[var(--negative)] shrink-0" />}
           <h3 id={titleId} className="text-[14px] font-semibold text-[var(--text-1)]">{title}</h3>
         </div>
         <p id={messageId} className="text-[13px] text-[var(--text-2)] leading-relaxed">{message}</p>

--- a/src/components/DebtSection.tsx
+++ b/src/components/DebtSection.tsx
@@ -5,18 +5,19 @@ import { useFinance, type Debt, type DebtType } from '../context/FinanceContext'
 import EditModal, { type ModalField } from './EditModal';
 import ConfirmModal from './ConfirmModal';
 import ChartTooltip from './ChartTooltip';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import { amortize, planPayoff, formatMonths, DEBT_TYPES, type PayoffStrategy } from '../lib/debt';
 import { parseLocaleNumber } from '../lib/validators';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
 
-// Debt-type role colours (concrete hex — reused for swatches and the chart).
+// Debt-type role colours (CHART token mirrors — reused for swatches and the chart).
 const DEBT_TYPE_COLOR: Record<DebtType, string> = {
-  student: '#3F7373',     // teal
-  consumer: '#5B7280',    // slate
-  credit_card: '#B5533A', // rust — typically the priciest
-  other: '#5F6555',       // text-dim
+  student: CHART.teal,
+  consumer: CHART.slate,
+  credit_card: CHART.rust, // typically the priciest
+  other: CHART.textDim,
 };
 
 interface ModalConfig {
@@ -180,15 +181,15 @@ export default function DebtSection() {
                   <AreaChart data={plan.balanceSeries} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
                     <defs>
                       <linearGradient id="debtGrad" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="0%" stopColor="#B5533A" stopOpacity={0.18} />
-                        <stop offset="100%" stopColor="#B5533A" stopOpacity={0.18} />
+                        <stop offset="0%" stopColor={CHART.rust} stopOpacity={0.18} />
+                        <stop offset="100%" stopColor={CHART.rust} stopOpacity={0.18} />
                       </linearGradient>
                     </defs>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-                    <XAxis dataKey="month" tickFormatter={(m: number) => `${Math.round(m / 12)}${t.common.yrAbbr}`} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
-                    <YAxis tickFormatter={fmtAxis} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={44} />
+                    <CartesianGrid {...GRID_PROPS} />
+                    <XAxis dataKey="month" tickFormatter={(m: number) => `${Math.round(m / 12)}${t.common.yrAbbr}`} {...AXIS_PROPS} />
+                    <YAxis tickFormatter={fmtAxis} {...AXIS_PROPS_Y} width={44} />
                     <Tooltip content={<ChartTooltip />} />
-                    <Area type="monotone" dataKey="total" name={d.sum} stroke="#B5533A" fill="url(#debtGrad)" strokeWidth={1.8} />
+                    <Area type="monotone" dataKey="total" name={d.sum} stroke={CHART.rust} fill="url(#debtGrad)" strokeWidth={1.8} />
                   </AreaChart>
                 </ResponsiveContainer>
               </div>

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -100,7 +100,7 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
                   value={values[field.key]}
                   onChange={(e) => setValues(prev => ({ ...prev, [field.key]: e.target.value }))}
                   onKeyDown={handleKeyDown}
-                  className="w-full bg-[var(--bg-raised)] border border-[var(--border)] rounded-[6px] px-4 py-3 text-[14px] text-[var(--text-1)] focus:outline-none focus:ring-2 focus:ring-[#7FCBA0]"
+                  className="w-full bg-[var(--bg-raised)] border border-[var(--border)] rounded-[6px] px-4 py-3 text-[14px] text-[var(--text-1)] focus:outline-none focus:ring-2 focus:ring-[var(--positive)]"
                 >
                   {(field.options ?? []).map(opt => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -118,7 +118,7 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
                     autoComplete={field.suggestions ? 'off' : undefined}
                     onChange={(e) => setValues(prev => ({ ...prev, [field.key]: e.target.value }))}
                     onKeyDown={handleKeyDown}
-                    className="w-full bg-[var(--bg-raised)] border border-[var(--border)] rounded-[6px] px-4 py-3 text-[14px] font-mono text-[var(--text-1)] focus:outline-none focus:ring-2 focus:ring-[#7FCBA0] placeholder:text-[var(--text-2)] placeholder:font-sans"
+                    className="w-full bg-[var(--bg-raised)] border border-[var(--border)] rounded-[6px] px-4 py-3 text-[14px] font-mono text-[var(--text-1)] focus:outline-none focus:ring-2 focus:ring-[var(--positive)] placeholder:text-[var(--text-2)] placeholder:font-sans"
                   />
                   {field.suggestions && field.suggestions.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 pt-1">
@@ -150,7 +150,7 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
             </div>
           ))}
           {error && (
-            <p className="text-[12px] text-[#B5533A] font-medium">{error}</p>
+            <p className="text-[12px] text-[var(--negative)] font-medium">{error}</p>
           )}
         </div>
 

--- a/src/components/FunBudget.tsx
+++ b/src/components/FunBudget.tsx
@@ -16,8 +16,8 @@ function FunStat({ label, value, negative, highlight }: FunStatProps) {
     <div className="flex flex-col gap-1.5 bg-[var(--bg-raised)] border border-[var(--border)] rounded-[8px] p-3 md:p-4">
       <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-2)]">{label}</span>
       <span className={`text-[13px] md:text-[15px] font-bold font-mono tracking-tight ${
-        negative ? 'text-[#B5533A]' :
-        highlight ? 'text-[#B5533A]' :
+        negative ? 'text-[var(--negative)]' :
+        highlight ? 'text-[var(--negative)]' :
         'text-[var(--text-1)]'
       }`}>
         {negative ? '−' : ''}{value}
@@ -71,9 +71,9 @@ export default function FunBudget() {
         <div className="h-3 bg-[var(--bg-elev)] rounded-full overflow-hidden">
           <div
             className={`h-full rounded-full transition-all duration-700 ${
-              pct >= 100 ? 'bg-[#B5533A]' :
+              pct >= 100 ? 'bg-[var(--negative)]' :
               pct >= 75 ? 'bg-[var(--brass)]' :
-              'bg-[#7FCBA0]'
+              'bg-[var(--positive)]'
             }`}
             style={{ width: `${pct}%` }}
           />
@@ -86,7 +86,7 @@ export default function FunBudget() {
       </div>
 
       {funRemaining < 0 && (
-        <div className="mt-3 text-[12px] text-[#B5533A] font-medium">
+        <div className="mt-3 text-[12px] text-[var(--negative)] font-medium">
           {t.funBudgetOverspent} {formatCurrency(Math.abs(funRemaining))}
         </div>
       )}

--- a/src/components/GoalsSection.tsx
+++ b/src/components/GoalsSection.tsx
@@ -192,7 +192,7 @@ const GoalsSection: React.FC = () => {
                     <button aria-label={`${t.edit} — ${g.name}`} onClick={() => openModal(g)} className="p-1 rounded text-[var(--text-2)] hover:text-[var(--text-1)] opacity-0 group-hover:opacity-100 transition-opacity">
                       <Edit2 size={12} />
                     </button>
-                    <button aria-label={`${t.delete} — ${g.name}`} onClick={() => confirmDelete(g)} className="p-1 rounded text-[var(--text-2)] hover:text-[#B5533A] opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button aria-label={`${t.delete} — ${g.name}`} onClick={() => confirmDelete(g)} className="p-1 rounded text-[var(--text-2)] hover:text-[var(--negative)] opacity-0 group-hover:opacity-100 transition-opacity">
                       <Trash2 size={12} />
                     </button>
                   </div>

--- a/src/components/MonthlyAccountSpend.tsx
+++ b/src/components/MonthlyAccountSpend.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { format, subMonths } from 'date-fns';
+import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../context/FinanceContext';
 import { accountMonthlyTotals, monthlyColumnTotals } from '../lib/monthlySpend';
 import { accountToken } from '../lib/accountColor';
@@ -9,7 +10,8 @@ const MONTHS = 6;
 // Spending per connected account per month (last 6), from the real transaction
 // data (internal transfers netted out). Hidden when no account-tagged spend.
 export function MonthlyAccountSpend() {
-  const { t, currentMonth, nonTransferTransactions, accountLabels, formatCurrency } = useFinance();
+  const { t, lang, currentMonth, nonTransferTransactions, accountLabels, formatCurrency } = useFinance();
+  const dateLocale = lang === 'nb' ? nb : enUS;
 
   const { months, rows, colTotals } = useMemo(() => {
     const months = Array.from({ length: MONTHS }, (_, i) => format(subMonths(currentMonth, MONTHS - 1 - i), 'yyyy-MM'));
@@ -32,7 +34,7 @@ export function MonthlyAccountSpend() {
               <th className="text-left font-medium py-1.5 pr-3">{t.budgetPage.accountFilterLabel}</th>
               {months.map((m) => (
                 <th key={m} className="text-right font-medium py-1.5 px-2 whitespace-nowrap capitalize">
-                  {format(new Date(`${m}-01T00:00:00`), 'MMM')}
+                  {format(new Date(`${m}-01T00:00:00`), 'MMM', { locale: dateLocale })}
                 </th>
               ))}
               <th className="text-right font-semibold py-1.5 pl-2">{t.budgetPage.total}</th>

--- a/src/components/NetWorthHistoryModal.tsx
+++ b/src/components/NetWorthHistoryModal.tsx
@@ -109,7 +109,7 @@ export default function NetWorthHistoryModal({ series, formatCurrency, onClose }
                       onChange={(e) => setDrafts(prev => ({ ...prev, [p.monthKey]: e.target.value }))}
                       onBlur={(e) => commit(p.monthKey, e.target.value)}
                       onKeyDown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
-                      className="flex-1 min-w-0 h-9 px-3 rounded-[8px] text-[13px] font-mono outline-none border focus:ring-2 focus:ring-[#7FCBA0]"
+                      className="flex-1 min-w-0 h-9 px-3 rounded-[8px] text-[13px] font-mono outline-none border focus:ring-2 focus:ring-[var(--positive)]"
                       style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
                     />
                     <ProvenanceBadge kind={p.estimated ? 'estimate' : 'custom'} />

--- a/src/components/PayslipImportModal.tsx
+++ b/src/components/PayslipImportModal.tsx
@@ -384,7 +384,7 @@ export default function PayslipImportModal({ onClose }: { onClose: () => void })
 
         {phase.kind === 'error' && (
           <>
-            <p className="text-[13px] text-[#B5533A] leading-relaxed">{phase.message}</p>
+            <p className="text-[13px] text-[var(--negative)] leading-relaxed">{phase.message}</p>
             <button
               onClick={() => setPhase({ kind: 'idle' })}
               className="w-full py-2.5 rounded-[6px] text-[13px] font-medium text-[var(--text-2)] bg-[var(--bg-elev)] hover:bg-[var(--bg-raised)] transition-colors"

--- a/src/components/charts/CashflowChart.tsx
+++ b/src/components/charts/CashflowChart.tsx
@@ -3,9 +3,10 @@ import {
   ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
 } from 'recharts';
 import { format, subMonths } from 'date-fns';
+import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 
 /**
  * Monthly cashflow for the last 12 months: money in (income) vs money out
@@ -16,11 +17,12 @@ import { CHART } from '../../lib/chartColors';
  */
 export default function CashflowChart() {
   const {
-    t, currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses,
+    t, lang, currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses,
     // Whole-finance cashflow: net out internal transfers, but not per-account (income
     // isn't account-scoped), so use nonTransferTransactions.
     nonTransferTransactions: dailyTransactions, formatCurrencyShort,
   } = useFinance();
+  const dateLocale = lang === 'nb' ? nb : enUS;
 
   const data = useMemo(() => {
     return Array.from({ length: 12 }, (_, i) => {
@@ -31,16 +33,16 @@ export default function CashflowChart() {
         .filter(tx => tx.date.startsWith(key) && tx.kind !== 'income')
         .reduce((s, tx) => s + tx.amount, 0);
       const expenses = totalFixedExpenses + variable;
-      return { label: format(d, 'MMM'), income, expenses, net: income - expenses };
+      return { label: format(d, 'MMM', { locale: dateLocale }), income, expenses, net: income - expenses };
     });
-  }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions]);
+  }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions, dateLocale]);
 
   return (
     <ResponsiveContainer width="100%" height="100%">
       <ComposedChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 4 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-        <XAxis dataKey="label" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} />
-        <YAxis tickFormatter={formatCurrencyShort} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={44} />
+        <CartesianGrid {...GRID_PROPS} vertical={false} />
+        <XAxis dataKey="label" {...AXIS_PROPS} />
+        <YAxis tickFormatter={formatCurrencyShort} {...AXIS_PROPS_Y} width={44} />
         <Tooltip cursor={{ fill: CHART.track }} content={<ChartTooltip />} />
         <ReferenceLine y={0} stroke={CHART.rule} />
         <Bar name={t.charts.income} dataKey="income" fill={CHART.forestLight} radius={[2, 2, 0, 0]} maxBarSize={18} />

--- a/src/components/charts/CategoryTrendChart.tsx
+++ b/src/components/charts/CategoryTrendChart.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
 import { format, subMonths } from 'date-fns';
+import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 import { CATEGORIES } from '../../lib/categories';
 import { monthlyCategoryTotals } from '../../lib/categoryStats';
 
@@ -13,18 +14,19 @@ const MONTHS = 6;
 // category's spend moves over time. Only categories with spend in the window get
 // a series, so an all-groceries user doesn't see 11 empty legend entries.
 export default function CategoryTrendChart() {
-  const { t, currentMonth, visibleBudgetTransactions: dailyTransactions, formatCurrencyShort } = useFinance();
+  const { t, lang, currentMonth, visibleBudgetTransactions: dailyTransactions, formatCurrencyShort } = useFinance();
+  const dateLocale = lang === 'nb' ? nb : enUS;
 
   const { data, series } = useMemo(() => {
     const months = Array.from({ length: MONTHS }, (_, i) => format(subMonths(currentMonth, MONTHS - 1 - i), 'yyyy-MM'));
     const rows = monthlyCategoryTotals(dailyTransactions, months);
-    const data = rows.map((r) => ({ ...r, label: format(new Date(`${r.month}-01T00:00:00`), 'MMM') }));
+    const data = rows.map((r) => ({ ...r, label: format(new Date(`${r.month}-01T00:00:00`), 'MMM', { locale: dateLocale }) }));
     // Keep only categories that appear at least once across the window.
     // monthlyCategoryTotals only writes a key when its value > 0, so a numeric
     // value in any row means the category has spend.
     const present = CATEGORIES.filter((c) => rows.some((r) => typeof r[c.key] === 'number'));
     return { data, series: present };
-  }, [currentMonth, dailyTransactions]);
+  }, [currentMonth, dailyTransactions, dateLocale]);
 
   const hasData = data.some((r) => r.total > 0);
   if (!hasData) {
@@ -35,9 +37,9 @@ export default function CategoryTrendChart() {
     <div className="w-full h-[220px]">
       <ResponsiveContainer width="100%" height="100%">
         <BarChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 4 }}>
-          <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-          <XAxis dataKey="label" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} />
-          <YAxis tickFormatter={formatCurrencyShort} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={44} />
+          <CartesianGrid {...GRID_PROPS} vertical={false} />
+          <XAxis dataKey="label" {...AXIS_PROPS} />
+          <YAxis tickFormatter={formatCurrencyShort} {...AXIS_PROPS_Y} width={44} />
           <Tooltip cursor={{ fill: CHART.track }} content={<ChartTooltip />} />
           {series.map((c, i) => (
             <Bar key={c.key} name={t.categoryLabels[c.key]} dataKey={c.key} stackId="s" fill={c.color} maxBarSize={32}>

--- a/src/components/charts/DebtPayoffChart.tsx
+++ b/src/components/charts/DebtPayoffChart.tsx
@@ -1,7 +1,7 @@
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 
 interface DebtPayoffChartProps {
   /** Mortgage balance at each year, index 0..N (year 0 = today). */
@@ -65,9 +65,9 @@ export default function DebtPayoffChart({ balances, startYear, nonMortgageDebt }
                 <stop offset="100%" stopColor={CHART.rust} stopOpacity={0.04} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-            <XAxis dataKey="year" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} />
-            <YAxis tickFormatter={formatCurrencyShort} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={44} />
+            <CartesianGrid {...GRID_PROPS} vertical={false} />
+            <XAxis dataKey="year" {...AXIS_PROPS} />
+            <YAxis tickFormatter={formatCurrencyShort} {...AXIS_PROPS_Y} width={44} />
             <Tooltip cursor={{ stroke: CHART.rule }} content={<ChartTooltip valueFormatter={(v) => formatCurrency(v)} />} />
             <Area type="monotone" dataKey="debt" name={t.charts.mortgageToday} stroke={CHART.rust} strokeWidth={2} fill="url(#debtGrad)" />
           </AreaChart>

--- a/src/components/charts/LtvChart.tsx
+++ b/src/components/charts/LtvChart.tsx
@@ -3,7 +3,7 @@ import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import { useFinance } from '../../context/FinanceContext';
 import { calcAmortizationSchedule } from '../../lib/calculations';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 
 /**
  * Loan-to-value over time for a homeowner: the mortgage shrinks as it amortizes
@@ -36,9 +36,9 @@ export default function LtvChart() {
             <stop offset="100%" stopColor={CHART.teal} stopOpacity={0.02} />
           </linearGradient>
         </defs>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-        <XAxis dataKey="year" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} interval="preserveStartEnd" minTickGap={28} />
-        <YAxis tickFormatter={(v) => `${v}%`} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={40} domain={[0, 'auto']} />
+        <CartesianGrid {...GRID_PROPS} vertical={false} />
+        <XAxis dataKey="year" {...AXIS_PROPS} interval="preserveStartEnd" minTickGap={28} />
+        <YAxis tickFormatter={(v) => `${v}%`} {...AXIS_PROPS_Y} width={40} domain={[0, 'auto']} />
         <Tooltip content={<ChartTooltip valueFormatter={(v) => `${v.toFixed(1)}%`} labelFormatter={(l) => String(l)} />} />
         <ReferenceLine y={85} stroke={CHART.rust} strokeDasharray="4 4" label={{ value: t.charts.ltvCap, position: 'insideTopRight', fontSize: 10, fill: CHART.rust }} />
         <Area name={t.charts.ltv} type="monotone" dataKey="ltv" stroke={CHART.teal} strokeWidth={2} fill="url(#ltvFill)" />

--- a/src/components/charts/NetWorthCompositionChart.tsx
+++ b/src/components/charts/NetWorthCompositionChart.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { format, parse } from 'date-fns';
+import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import { computeEquityBreakdown } from '../../lib/equity';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 
 /**
  * How net-worth composition (stocks / house equity / crypto / cash) has shifted
@@ -13,7 +14,8 @@ import { CHART } from '../../lib/chartColors';
  * months accumulate.
  */
 export default function NetWorthCompositionChart() {
-  const { t, balanceSnapshots, assets, currentMonth, formatCurrencyShort } = useFinance();
+  const { t, lang, balanceSnapshots, assets, currentMonth, formatCurrencyShort } = useFinance();
+  const dateLocale = lang === 'nb' ? nb : enUS;
 
   const data = useMemo(() => {
     const curKey = format(currentMonth, 'yyyy-MM');
@@ -22,14 +24,14 @@ export default function NetWorthCompositionChart() {
       const a = key === curKey ? assets : (balanceSnapshots[key]?.assets ?? assets);
       const eq = computeEquityBreakdown(a);
       return {
-        label: format(parse(key, 'yyyy-MM', new Date()), 'MMM yy'),
+        label: format(parse(key, 'yyyy-MM', new Date()), 'MMM yy', { locale: dateLocale }),
         stocks: Math.round(eq.netInvestment),
         house: Math.round(eq.houseEquity),
         crypto: Math.round(eq.netCrypto),
         cash: Math.round(eq.savingsTotal + a.bsu + a.bufferAccount),
       };
     });
-  }, [balanceSnapshots, assets, currentMonth]);
+  }, [balanceSnapshots, assets, currentMonth, dateLocale]);
 
   if (data.length < 2) {
     return (
@@ -49,9 +51,9 @@ export default function NetWorthCompositionChart() {
   return (
     <ResponsiveContainer width="100%" height="100%">
       <AreaChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 4 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-        <XAxis dataKey="label" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} />
-        <YAxis tickFormatter={formatCurrencyShort} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={44} />
+        <CartesianGrid {...GRID_PROPS} vertical={false} />
+        <XAxis dataKey="label" {...AXIS_PROPS} />
+        <YAxis tickFormatter={formatCurrencyShort} {...AXIS_PROPS_Y} width={44} />
         <Tooltip cursor={{ stroke: CHART.rule }} content={<ChartTooltip />} />
         {areas.map(a => (
           <Area

--- a/src/components/charts/SavingsRateChart.tsx
+++ b/src/components/charts/SavingsRateChart.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
 import { format, subMonths } from 'date-fns';
+import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
-import { CHART } from '../../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
 
 /**
  * Monthly savings capacity as a rate: the share of income left after fixed
@@ -12,11 +13,12 @@ import { CHART } from '../../lib/chartColors';
  */
 export default function SavingsRateChart() {
   const {
-    t, currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses,
+    t, lang, currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses,
     // Whole-finance rate: net out internal transfers, but not per-account (income
     // isn't account-scoped), so use nonTransferTransactions.
     nonTransferTransactions: dailyTransactions, savingsTargetPercent,
   } = useFinance();
+  const dateLocale = lang === 'nb' ? nb : enUS;
 
   const data = useMemo(() => {
     return Array.from({ length: 12 }, (_, i) => {
@@ -27,16 +29,16 @@ export default function SavingsRateChart() {
         .filter(tx => tx.date.startsWith(key) && tx.kind !== 'income')
         .reduce((s, tx) => s + tx.amount, 0);
       const rate = income > 0 ? ((income - totalFixedExpenses - variable) / income) * 100 : 0;
-      return { label: format(d, 'MMM'), rate: Math.round(rate * 10) / 10 };
+      return { label: format(d, 'MMM', { locale: dateLocale }), rate: Math.round(rate * 10) / 10 };
     });
-  }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions]);
+  }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions, dateLocale]);
 
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 4 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.grid} />
-        <XAxis dataKey="label" tick={{ fontSize: 11, fill: CHART.textSoft }} axisLine={false} tickLine={false} />
-        <YAxis tickFormatter={(v) => `${v}%`} tick={{ fontSize: 10, fill: CHART.textDim }} axisLine={false} tickLine={false} width={40} />
+        <CartesianGrid {...GRID_PROPS} vertical={false} />
+        <XAxis dataKey="label" {...AXIS_PROPS} />
+        <YAxis tickFormatter={(v) => `${v}%`} {...AXIS_PROPS_Y} width={40} />
         <Tooltip content={<ChartTooltip valueFormatter={(v) => `${v.toFixed(1)}%`} />} />
         <ReferenceLine y={savingsTargetPercent} stroke={CHART.brass} strokeDasharray="4 4" label={{ value: t.charts.target, position: 'insideTopRight', fontSize: 10, fill: CHART.brass }} />
         <Line name={t.charts.savingsRate} type="monotone" dataKey="rate" stroke={CHART.forestLight} strokeWidth={2} dot={{ r: 2, fill: CHART.forestLight }} />

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -20,3 +20,23 @@ export const CHART = {
 
 // Categorical series colour order (matches the 4 category hues + accents).
 export const SERIES = [CHART.teal, CHART.forest, CHART.slate, CHART.forestLight, CHART.brass, CHART.rust];
+
+// Shared Recharts prop blocks — the one axis/grid treatment every chart uses.
+// Spread them (`<XAxis {...AXIS_PROPS} …>`, `<YAxis {...AXIS_PROPS_Y} …>`,
+// `<CartesianGrid {...GRID_PROPS} …>`); per-chart extras (width, tickFormatter,
+// vertical, domain) stay as ordinary props after the spread. Deliberate
+// exceptions (emphasised year axes, category labels) keep their own tick.
+export const AXIS_PROPS = {
+  tick: { fontSize: 11, fill: CHART.textSoft },
+  axisLine: false,
+  tickLine: false,
+} as const;
+export const AXIS_PROPS_Y = {
+  tick: { fontSize: 10, fill: CHART.textDim },
+  axisLine: false,
+  tickLine: false,
+} as const;
+export const GRID_PROPS = {
+  strokeDasharray: '3 3',
+  stroke: CHART.grid,
+} as const;

--- a/src/pages/AssetPage.tsx
+++ b/src/pages/AssetPage.tsx
@@ -30,7 +30,7 @@ import EditModal, { type ModalField } from '../components/EditModal';
 import { EquityCompositionBar } from '../components/EquityCompositionBar';
 import DebtSection from '../components/DebtSection';
 import ChartTooltip from '../components/ChartTooltip';
-import { CHART } from '../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import { computeEquityBreakdown, sumSavings } from '../lib/equity';
@@ -568,9 +568,9 @@ const AssetPage: React.FC = () => {
                   <stop offset="100%" stopColor={CHART.teal} stopOpacity={0.85} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke={CHART.rule} />
-              <XAxis dataKey="year" tick={{ fontSize: 11, fill: CHART.textDim }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={formatAxisValue} tick={{ fontSize: 11, fill: CHART.textDim }} axisLine={false} tickLine={false} width={52} />
+              <CartesianGrid {...GRID_PROPS} />
+              <XAxis dataKey="year" {...AXIS_PROPS} />
+              <YAxis tickFormatter={formatAxisValue} {...AXIS_PROPS_Y} width={52} />
               <Tooltip content={<ChartTooltip />} />
               <Area type="monotone" dataKey="house" stackId="1" name={t.bucketHouse} stroke={CHART.teal} fill="url(#houseGrad)" />
               <Area type="monotone" dataKey="cash" stackId="1" name={t.bucketCash} stroke={CHART.slate} fill="url(#cashGrad)" />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -574,7 +574,7 @@ const DashboardPage: React.FC = () => {
                         <div
                           key={i}
                           className="flex items-center justify-center font-mono text-[10px]"
-                          style={{ width: `${pct}%`, background: r.color, color: '#0E1310' }}
+                          style={{ width: `${pct}%`, background: r.color, color: 'var(--bg-page)' }}
                           title={r.label}
                         >
                           {pct >= 10 ? `${pct.toFixed(0)}%` : ''}

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -5,6 +5,7 @@ import {
 import { TrendingUp, Wallet, Activity } from 'lucide-react';
 import { useFinance } from '../context/FinanceContext';
 import ChartTooltip from '../components/ChartTooltip';
+import { AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import { calcTaxByRegion, IPS_MAX_DEDUCTION } from '../lib/norwegianTax';
 import { currentMonthKey } from '../lib/date';
 import { salaryAt } from '../lib/salary';
@@ -232,9 +233,9 @@ const ForecastPage: React.FC = () => {
                   <stop offset="100%" stopColor="var(--violet)" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-              <XAxis dataKey="yearLabel" tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={52} />
+              <CartesianGrid {...GRID_PROPS} />
+              <XAxis dataKey="yearLabel" {...AXIS_PROPS} />
+              <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip
                 content={<ChartTooltip />}
                 cursor={{ stroke: 'var(--text-3)', strokeWidth: 1, strokeDasharray: '3 3' }}
@@ -261,9 +262,9 @@ const ForecastPage: React.FC = () => {
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={projection} margin={{ top: 12, right: 8, left: 0, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-              <XAxis dataKey="yearLabel" tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={52} />
+              <CartesianGrid {...GRID_PROPS} />
+              <XAxis dataKey="yearLabel" {...AXIS_PROPS} />
+              <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip content={<ChartTooltip />} />
               <Line type="monotone" dataKey="gross" name={t.forecast.grossSalary} stroke="var(--accent)" strokeWidth={2.5} dot={false} />
               <Line type="monotone" dataKey="net" name={t.forecast.netTakeHome} stroke="var(--positive)" strokeWidth={2.5} dot={false} />

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -36,7 +36,7 @@ import {
 } from '../context/FinanceContext';
 import EditModal, { type ModalField } from '../components/EditModal';
 import ChartTooltip from '../components/ChartTooltip';
-import { CHART } from '../lib/chartColors';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import { computeEquityBreakdown, sumSavings } from '../lib/equity';
@@ -786,19 +786,15 @@ function AmortizationAccordion({ show, onToggle, schedule, chartData, t, formatC
             <div className="h-[200px] md:h-[260px] w-full">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={CHART.rule} />
+                  <CartesianGrid {...GRID_PROPS} vertical={false} />
                   <XAxis
                     dataKey="year"
-                    tick={{ fontSize: 11, fill: CHART.textDim }}
-                    axisLine={false}
-                    tickLine={false}
+                    {...AXIS_PROPS}
                     tickFormatter={(v) => `${t.loanPage.yearAxisPrefix} ${v}`}
                   />
                   <YAxis
                     tickFormatter={(v) => v >= 1_000_000 ? `${(v / 1_000_000).toFixed(1)}M` : `${Math.round(v / 1_000)}k`}
-                    tick={{ fontSize: 11, fill: CHART.textDim }}
-                    axisLine={false}
-                    tickLine={false}
+                    {...AXIS_PROPS_Y}
                     width={48}
                   />
                   <Tooltip

--- a/src/pages/PensionPage.tsx
+++ b/src/pages/PensionPage.tsx
@@ -15,6 +15,7 @@ import { currentMonthKey } from '../lib/date';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import ChartTooltip from '../components/ChartTooltip';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 
 function formatAxisInt(val: number): string {
   if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
@@ -145,26 +146,26 @@ const PensionPage: React.FC = () => {
                 <AreaChart data={projection} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
                   <defs>
                     <linearGradient id="otpGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#1F5A42" stopOpacity={0.92} />
-                      <stop offset="100%" stopColor="#1F5A42" stopOpacity={0.92} />
+                      <stop offset="0%" stopColor={CHART.forest} stopOpacity={0.92} />
+                      <stop offset="100%" stopColor={CHART.forest} stopOpacity={0.92} />
                     </linearGradient>
                     <linearGradient id="ipsGrad" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="0%" stopColor="#3F7373" stopOpacity={0.85} />
-                      <stop offset="100%" stopColor="#3F7373" stopOpacity={0.85} />
+                      <stop offset="0%" stopColor={CHART.teal} stopOpacity={0.85} />
+                      <stop offset="100%" stopColor={CHART.teal} stopOpacity={0.85} />
                     </linearGradient>
                   </defs>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-                  <XAxis dataKey="year" tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
-                  <YAxis tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={52} />
+                  <CartesianGrid {...GRID_PROPS} />
+                  <XAxis dataKey="year" {...AXIS_PROPS} />
+                  <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
                   <Tooltip content={<ChartTooltip />} />
-                  <Area type="monotone" dataKey="ips" stackId="1" name="IPS" stroke="#3F7373" fill="url(#ipsGrad)" />
-                  <Area type="monotone" dataKey="otp" stackId="1" name="OTP" stroke="#7FCBA0" fill="url(#otpGrad)" />
+                  <Area type="monotone" dataKey="ips" stackId="1" name="IPS" stroke={CHART.teal} fill="url(#ipsGrad)" />
+                  <Area type="monotone" dataKey="otp" stackId="1" name="OTP" stroke={CHART.forestLight} fill="url(#otpGrad)" />
                 </AreaChart>
               </ResponsiveContainer>
             </div>
             <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-[11px] mt-3" style={{ color: 'var(--text-2)' }}>
-              <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#7FCBA0' }} />OTP</div>
-              <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#3F7373' }} />IPS</div>
+              <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.forestLight }} />OTP</div>
+              <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.teal }} />IPS</div>
             </div>
           </>
         )}

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -39,6 +39,7 @@ import type { Translations } from '../i18n/translations';
 import EditModal, { type ModalField } from '../components/EditModal';
 import ConfirmModal from '../components/ConfirmModal';
 import ChartTooltip from '../components/ChartTooltip';
+import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import { calcTaxByRegion } from '../lib/norwegianTax';
 import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from '../lib/date';
 import { salaryAt, hoursAt } from '../lib/salary';
@@ -54,7 +55,7 @@ const MoneyFlowSankey = lazy(() => import('../components/charts/MoneyFlowSankey'
 const WEEKS_PER_MONTH = 4.345;
 
 const CHANGE_TYPE_COLOR: Record<SalaryChangeType, string> = {
-  initial: '#5F6555',
+  initial: 'var(--text-dim)',
   raise: 'var(--positive)',
   promotion: 'var(--violet)',
   job_change: 'var(--accent)',
@@ -857,9 +858,9 @@ const SalaryPage: React.FC = () => {
                   <stop offset="0%" stopColor="var(--accent)" stopOpacity={0.12} /><stop offset="100%" stopColor="var(--accent)" stopOpacity={0.12} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-              <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={52} />
+              <CartesianGrid {...GRID_PROPS} />
+              <XAxis dataKey="month" {...AXIS_PROPS} />
+              <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip content={<ChartTooltip />} />
               {jobChangeMonths.map(jc => (
                 <ReferenceLine
@@ -945,9 +946,9 @@ const SalaryPage: React.FC = () => {
         <div className="h-[300px] w-full">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={yoyByYear} margin={{ top: 28, right: 12, left: 0, bottom: 0 }} barGap={4} barCategoryGap="22%">
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
+              <CartesianGrid {...GRID_PROPS} />
               <XAxis dataKey="year" tick={{ fontSize: 12, fill: 'var(--text-2)', fontWeight: 600 }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={(v) => `${v}%`} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={44} />
+              <YAxis tickFormatter={(v) => `${v}%`} {...AXIS_PROPS_Y} width={44} />
               <Tooltip
                 content={<ChartTooltip valueFormatter={(v) => `${v.toFixed(1)}%`} />}
                 cursor={{ fill: 'rgba(255,255,255,0.03)' }}
@@ -1025,25 +1026,25 @@ const SalaryPage: React.FC = () => {
             <BarChart data={compByYear} margin={{ top: 28, right: 8, left: 0, bottom: 0 }} barCategoryGap="28%">
               <defs>
                 <linearGradient id="compBaseGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#1F5A42" stopOpacity={1} />
-                  <stop offset="100%" stopColor="#1F5A42" stopOpacity={1} />
+                  <stop offset="0%" stopColor={CHART.forest} stopOpacity={1} />
+                  <stop offset="100%" stopColor={CHART.forest} stopOpacity={1} />
                 </linearGradient>
                 <linearGradient id="compBonusGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#3F7373" stopOpacity={1} />
-                  <stop offset="100%" stopColor="#3F7373" stopOpacity={1} />
+                  <stop offset="0%" stopColor={CHART.teal} stopOpacity={1} />
+                  <stop offset="100%" stopColor={CHART.teal} stopOpacity={1} />
                 </linearGradient>
                 <linearGradient id="compOtGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#5B7280" stopOpacity={1} />
-                  <stop offset="100%" stopColor="#5B7280" stopOpacity={1} />
+                  <stop offset="0%" stopColor={CHART.slate} stopOpacity={1} />
+                  <stop offset="100%" stopColor={CHART.slate} stopOpacity={1} />
                 </linearGradient>
                 <linearGradient id="compOnCallGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stopColor="#7FCBA0" stopOpacity={1} />
-                  <stop offset="100%" stopColor="#7FCBA0" stopOpacity={1} />
+                  <stop offset="0%" stopColor={CHART.forestLight} stopOpacity={1} />
+                  <stop offset="100%" stopColor={CHART.forestLight} stopOpacity={1} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
+              <CartesianGrid {...GRID_PROPS} />
               <XAxis dataKey="year" tick={{ fontSize: 12, fill: 'var(--text-2)', fontWeight: 600 }} axisLine={false} tickLine={false} />
-              <YAxis tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={52} />
+              <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip
                 content={<ChartTooltip />}
                 cursor={{ fill: 'rgba(255,255,255,0.03)' }}
@@ -1059,10 +1060,10 @@ const SalaryPage: React.FC = () => {
         </div>
         {/* Inline legend */}
         <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-[11px]" style={{ color: 'var(--text-2)' }}>
-          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#1F5A42' }} />{t.salaryPage.baseSalary}</div>
-          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#7FCBA0' }} />{t.salary.onCallLabel}</div>
-          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#3F7373' }} />{t.salary.bonuses}</div>
-          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: '#5B7280' }} />{t.salary.overtime}</div>
+          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.forest }} />{t.salaryPage.baseSalary}</div>
+          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.forestLight }} />{t.salary.onCallLabel}</div>
+          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.teal }} />{t.salary.bonuses}</div>
+          <div className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm" style={{ background: CHART.slate }} />{t.salary.overtime}</div>
         </div>
       </div>
 
@@ -1081,10 +1082,10 @@ const SalaryPage: React.FC = () => {
                   <stop offset="0%" stopColor="var(--warning)" stopOpacity={0.85} /><stop offset="100%" stopColor="var(--warning)" stopOpacity={0.85} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
+              <CartesianGrid {...GRID_PROPS} />
               <XAxis dataKey="year" tick={{ fontSize: 12, fill: 'var(--text-2)', fontWeight: 600 }} axisLine={false} tickLine={false} />
-              <YAxis yAxisId="left" tickFormatter={(v) => `${v}t`} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={40} />
-              <YAxis yAxisId="right" orientation="right" tickFormatter={formatAxisInt} tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} width={56} />
+              <YAxis yAxisId="left" tickFormatter={(v) => `${v}t`} {...AXIS_PROPS_Y} width={40} />
+              <YAxis yAxisId="right" orientation="right" tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={56} />
               <Tooltip
                 cursor={{ fill: 'rgba(255,255,255,0.03)' }}
                 content={<ChartTooltip valueFormatter={(v, e) => e?.dataKey === 'hoursPerWeek' ? `${v.toFixed(1)} ${t.common.hoursPerWeekUnit}` : formatCurrency(v)} />}
@@ -1380,7 +1381,7 @@ const EntryList: React.FC<EntryListProps> = ({ title, icon, onAdd, empty, items,
               <button aria-label={`${editLabel} — ${item.primary}`} onClick={item.onEdit} className="p-1.5 rounded-md text-[var(--text-2)] hover:text-[var(--text-1)] hover:bg-[var(--bg-elev)] transition-colors">
                 <Edit2 size={13} />
               </button>
-              <button aria-label={`${deleteLabel} — ${item.primary}`} onClick={item.onDelete} className="p-1.5 rounded-md text-[var(--text-2)] hover:text-[#B5533A] hover:bg-[var(--bg-elev)] transition-colors">
+              <button aria-label={`${deleteLabel} — ${item.primary}`} onClick={item.onDelete} className="p-1.5 rounded-md text-[var(--text-2)] hover:text-[var(--negative)] hover:bg-[var(--bg-elev)] transition-colors">
                 <Trash2 size={13} />
               </button>
             </div>
@@ -1467,13 +1468,11 @@ const RealHourlyChart: React.FC<RealHourlyChartProps> = ({ series, formatCurrenc
                 <stop offset="100%" stopColor="var(--violet)" stopOpacity={0.1} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="#262A20" />
-            <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#5F6555' }} axisLine={false} tickLine={false} />
+            <CartesianGrid {...GRID_PROPS} />
+            <XAxis dataKey="month" {...AXIS_PROPS} />
             <YAxis
               tickFormatter={(v) => `${Math.round(v)}`}
-              tick={{ fontSize: 11, fill: '#5F6555' }}
-              axisLine={false}
-              tickLine={false}
+              {...AXIS_PROPS_Y}
               width={44}
             />
             <Tooltip


### PR DESCRIPTION
## Why

Audit finding 8.3: the Recharts axis/grid prop block (`tick={{ fontSize: 11, fill: ... }} axisLine={false} tickLine={false}` plus the grid twin) was copy-pasted ~26 times, forked between CHART.* tokens and their old hex twins (#5F6555 axis ink, #262A20 grids). Finding 5.5: raw hex colours outside chartColors.ts, in both SVG and CSS contexts. While verifying, the Kontantstrom chart turned out to show English month names in the Norwegian UI (same class as the DashboardPage locale fix already merged in #10).

## What

- `chartColors.ts` exports `AXIS_PROPS` / `AXIS_PROPS_Y` / `GRID_PROPS`; every chart spreads them (Dashboard lazy charts, DebtSection, BudgetDistributionChart, Asset/Loan/Forecast/Salary/Pension page charts). Per-chart extras (width, tickFormatter, vertical) stay as ordinary props. Deliberate exceptions (bold year axes on the Salary charts, category tick labels) keep their own tick object.
- Hex twins converge on tokens: page-chart axis ink moves from the old #5F6555 to the WCAG-lightened text-dim token, grids and gradient/legend stops use CHART.*, DEBT_TYPE_COLOR and the salary change-type map lose their literals.
- CSS contexts use theme vars instead of hex: FunBudget, GoalsSection delete hover, EditModal/NetWorthHistoryModal focus rings, ConfirmModal warning icon, PayslipImportModal error text, SalaryPage delete hover, CategoryBreakdown category fallback, Dashboard allocation-strip text. One bespoke shade (ConfirmModal's #9c4632 danger hover) has no token and stays.
- Month labels in CashflowChart, SavingsRateChart, CategoryTrendChart, NetWorthCompositionChart and MonthlyAccountSpend follow the date-fns locale.

Intentional small visual deltas: page-chart axis labels are slightly lighter (the accessibility-corrected token) and page-chart grids use the standard grid colour; everything now matches the Dashboard charts.

Not included: the recurring `rgba(255,255,255,0.0x)` background pattern from 5.5 (needs a new token, not a swap).

## Verification

- `npx tsc -b && npm run lint && npm test` green (350 tests).
- Docker build plus a browser pass over Dashboard, Salary, Forecast, Pension, Assets, Budget and Loan: all charts render, 0 console errors, Kontantstrom shows Norwegian month names.