### PR TITLE
One ModalShell for the four hand-rolled modals

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,7 +1,6 @@
-import ReactDOM from 'react-dom';
 import { useId } from 'react';
 import { AlertTriangle } from 'lucide-react';
-import { useFocusTrap } from '../hooks/useFocusTrap';
+import { ModalShell } from './ui/ModalShell';
 
 interface ConfirmModalProps {
   title: string;
@@ -16,27 +15,15 @@ interface ConfirmModalProps {
 export default function ConfirmModal({
   title, message, confirmLabel, cancelLabel, onConfirm, onCancel, danger = true
 }: ConfirmModalProps) {
-  const dialogRef = useFocusTrap<HTMLDivElement>(onCancel);
-  const titleId = useId();
   const messageId = useId();
-  const content = (
-    <div
-      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={messageId}
-        className="w-full sm:w-auto sm:min-w-[340px] sm:max-w-sm bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 space-y-4 border border-[var(--border)]"
-      >
-        <div className="flex items-center gap-3">
-          {danger && <AlertTriangle size={18} className="text-[var(--negative)] shrink-0" />}
-          <h3 id={titleId} className="text-[14px] font-semibold text-[var(--text-1)]">{title}</h3>
-        </div>
-        <p id={messageId} className="text-[13px] text-[var(--text-2)] leading-relaxed">{message}</p>
+  return (
+    <ModalShell
+      title={title}
+      onClose={onCancel}
+      icon={danger ? <AlertTriangle size={18} className="text-[var(--negative)] shrink-0" /> : undefined}
+      describedBy={messageId}
+      panelClassName="sm:min-w-[340px] sm:max-w-sm space-y-4"
+      footer={
         <div className="flex gap-2 pt-1">
           <button
             onClick={onCancel}
@@ -53,8 +40,9 @@ export default function ConfirmModal({
             {confirmLabel}
           </button>
         </div>
-      </div>
-    </div>
+      }
+    >
+      <p id={messageId} className="text-[13px] text-[var(--text-2)] leading-relaxed">{message}</p>
+    </ModalShell>
   );
-  return ReactDOM.createPortal(content, document.body);
 }

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -1,8 +1,6 @@
 import { useState, useRef, useId, type Ref } from 'react';
-import ReactDOM from 'react-dom';
-import { X } from 'lucide-react';
 import { useFinance } from '../context/FinanceContext';
-import { useFocusTrap } from '../hooks/useFocusTrap';
+import { ModalShell } from './ui/ModalShell';
 
 export interface ModalFieldOption {
   value: string;
@@ -36,9 +34,8 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
     () => Object.fromEntries(fields.map(f => [f.key, f.value]))
   );
   const firstInputRef = useRef<HTMLInputElement | HTMLSelectElement>(null);
-  const dialogRef = useFocusTrap<HTMLDivElement>(onCancel, firstInputRef);
-  const titleId = useId();
-  const fieldId = (key: string) => `${titleId}-${key}`;
+  const formId = useId();
+  const fieldId = (key: string) => `${formId}-${key}`;
   const actualCancelLabel = cancelLabel ?? t.cancel;
   const actualSaveLabel = saveLabel ?? t.save;
 
@@ -48,29 +45,30 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
     if (e.key === 'Enter') handleSave();
   };
 
-  const content = (
-    <div
-      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        className="w-full sm:w-auto sm:min-w-[360px] sm:max-w-sm bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 space-y-5 border border-[var(--border)]"
-      >
-        <div className="flex items-center justify-between">
-          <h3 id={titleId} className="text-[14px] font-semibold text-[var(--text-1)]">{title}</h3>
+  return (
+    <ModalShell
+      title={title}
+      onClose={onCancel}
+      closeLabel={t.cancel}
+      panelClassName="sm:min-w-[360px] sm:max-w-sm space-y-5"
+      initialFocus={firstInputRef}
+      footer={
+        <div className="flex gap-2 pt-1">
           <button
             onClick={onCancel}
-            aria-label={t.cancel}
-            className="p-1 rounded-lg text-[var(--text-2)] hover:text-[var(--text-1)] hover:bg-[var(--bg-elev)] transition-colors"
+            className="flex-1 py-2.5 rounded-[6px] text-[13px] font-medium text-[var(--text-2)] bg-[var(--bg-elev)] hover:bg-[var(--bg-raised)] transition-colors"
           >
-            <X size={16} />
+            {actualCancelLabel}
+          </button>
+          <button
+            onClick={handleSave}
+            className="flex-1 py-2.5 rounded-[6px] text-[13px] font-semibold text-[var(--text)] bg-[var(--forest)] hover:bg-[var(--forest-dim)] transition-opacity"
+          >
+            {actualSaveLabel}
           </button>
         </div>
-
+      }
+    >
         <div className="space-y-3">
           {fields.map((field, idx) => field.type === 'checkbox' ? (
             <div key={field.key} className="space-y-1.5">
@@ -153,24 +151,6 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
             <p className="text-[12px] text-[var(--negative)] font-medium">{error}</p>
           )}
         </div>
-
-        <div className="flex gap-2 pt-1">
-          <button
-            onClick={onCancel}
-            className="flex-1 py-2.5 rounded-[6px] text-[13px] font-medium text-[var(--text-2)] bg-[var(--bg-elev)] hover:bg-[var(--bg-raised)] transition-colors"
-          >
-            {actualCancelLabel}
-          </button>
-          <button
-            onClick={handleSave}
-            className="flex-1 py-2.5 rounded-[6px] text-[13px] font-semibold text-[var(--text)] bg-[var(--forest)] hover:bg-[var(--forest-dim)] transition-opacity"
-          >
-            {actualSaveLabel}
-          </button>
-        </div>
-      </div>
-    </div>
+    </ModalShell>
   );
-
-  return ReactDOM.createPortal(content, document.body);
 }

--- a/src/components/NetWorthHistoryModal.tsx
+++ b/src/components/NetWorthHistoryModal.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
-import { X, RotateCcw, Camera } from 'lucide-react';
+import { useState } from 'react';
+import { RotateCcw, Camera } from 'lucide-react';
 import { format, parse } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../context/FinanceContext';
 import { parseLocaleNumber } from '../lib/validators';
 import { ProvenanceBadge } from './ui/ProvenanceBadge';
+import { ModalShell } from './ui/ModalShell';
 
 export interface NetWorthPoint {
   monthKey: string;
@@ -32,12 +32,6 @@ export default function NetWorthHistoryModal({ series, formatCurrency, onClose }
     Object.fromEntries(series.map(p => [p.monthKey, p.estimated ? '' : String(p.value)]))
   );
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
   const commit = (monthKey: string, raw: string) => {
     const trimmed = raw.trim();
     if (trimmed === '') { clearNetWorthForMonth(monthKey); return; }
@@ -52,23 +46,21 @@ export default function NetWorthHistoryModal({ series, formatCurrency, onClose }
 
   const rows = [...series].reverse(); // newest first
 
-  const content = (
-    <div
-      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+  return (
+    <ModalShell
+      title={nw.title}
+      onClose={onClose}
+      closeLabel={nw.done}
+      panelClassName="sm:min-w-[420px] sm:max-w-md space-y-4 max-h-[85vh] flex flex-col"
+      footer={
+        <button
+          onClick={onClose}
+          className="shrink-0 w-full py-2.5 rounded-[8px] text-[13px] font-semibold text-[var(--text)] bg-[var(--forest)] hover:bg-[var(--forest-dim)] transition-opacity"
+        >
+          {nw.done}
+        </button>
+      }
     >
-      <div className="w-full sm:w-auto sm:min-w-[420px] sm:max-w-md bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 space-y-4 border border-[var(--border)] max-h-[85vh] flex flex-col">
-        <div className="flex items-center justify-between shrink-0">
-          <h3 className="text-[14px] font-semibold text-[var(--text-1)]">{nw.title}</h3>
-          <button
-            onClick={onClose}
-            className="p-1 rounded-lg text-[var(--text-2)] hover:text-[var(--text-1)] hover:bg-[var(--bg-elev)] transition-colors"
-            aria-label={nw.done}
-          >
-            <X size={16} />
-          </button>
-        </div>
-
         <p className="text-[12px] leading-relaxed shrink-0" style={{ color: 'var(--text-3)' }}>{nw.desc}</p>
 
         <div className="space-y-1.5 overflow-y-auto -mx-1 px-1">
@@ -131,16 +123,6 @@ export default function NetWorthHistoryModal({ series, formatCurrency, onClose }
             );
           })}
         </div>
-
-        <button
-          onClick={onClose}
-          className="shrink-0 w-full py-2.5 rounded-[8px] text-[13px] font-semibold text-[var(--text)] bg-[var(--forest)] hover:bg-[var(--forest-dim)] transition-opacity"
-        >
-          {nw.done}
-        </button>
-      </div>
-    </div>
+    </ModalShell>
   );
-
-  return ReactDOM.createPortal(content, document.body);
 }

--- a/src/components/PayslipImportModal.tsx
+++ b/src/components/PayslipImportModal.tsx
@@ -1,8 +1,9 @@
-import { useId, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Check, FileText, Loader2, Maximize2, Upload, X } from 'lucide-react';
 import { useFinance } from '../context/FinanceContext';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { ModalShell } from './ui/ModalShell';
 import { parsePayslip, parsePayslipAmount, PROVIDERS, type ParsedPayslip } from '../lib/payslip';
 
 /** One editable payslip row. Figure fields are strings so any misparse can be
@@ -65,11 +66,10 @@ export default function PayslipImportModal({ onClose }: { onClose: () => void })
   const [singleThumb, setSingleThumb] = useState<string | null>(null);
   const [preview, setPreview] = useState<{ pageIndex: number; url: string | null } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  // Modal trap stays active; the lightbox has its own trap that holds focus, so
-  // Escape there closes the preview first (not the whole modal).
-  const dialogRef = useFocusTrap<HTMLDivElement>(onClose);
+  // The shell's trap stays active; the lightbox (own portal, sibling tree) has
+  // its own trap that holds focus, so Escape there closes the preview first
+  // (not the whole modal).
   const lightboxRef = useFocusTrap<HTMLDivElement>(() => setPreview(null), undefined, preview !== null);
-  const titleId = useId();
 
   const single = rows.length === 1;
 
@@ -305,31 +305,14 @@ export default function PayslipImportModal({ onClose }: { onClose: () => void })
   );
 
   const content = (
-    <div
-      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center"
-      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        className={`w-full sm:w-auto ${phase.kind === 'review' && !single ? 'sm:min-w-[520px] sm:max-w-lg' : 'sm:min-w-[400px] sm:max-w-md'} bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 space-y-5 border border-[var(--border)] max-h-[90vh] overflow-y-auto`}
+    <>
+      <ModalShell
+        title={im.title}
+        onClose={onClose}
+        closeLabel={t.cancel}
+        icon={<FileText size={16} className="text-[var(--accent)]" />}
+        panelClassName={`${phase.kind === 'review' && !single ? 'sm:min-w-[520px] sm:max-w-lg' : 'sm:min-w-[400px] sm:max-w-md'} space-y-5 max-h-[90vh] overflow-y-auto`}
       >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <FileText size={16} className="text-[var(--accent)]" />
-            <h3 id={titleId} className="text-[14px] font-semibold text-[var(--text-1)]">{im.title}</h3>
-          </div>
-          <button
-            onClick={onClose}
-            aria-label={t.cancel}
-            className="p-1 rounded-md text-[var(--text-2)] hover:text-[var(--text-1)] hover:bg-[var(--bg-elev)] transition-colors"
-          >
-            <X size={16} />
-          </button>
-        </div>
-
         {phase.kind === 'idle' && (
           <>
             <p className="text-[13px] text-[var(--text-2)] leading-relaxed">{im.intro}</p>
@@ -395,10 +378,10 @@ export default function PayslipImportModal({ onClose }: { onClose: () => void })
         )}
 
         {phase.kind === 'review' && (single ? renderSingle() : renderBatch())}
-      </div>
+      </ModalShell>
 
       {/* Full-size preview lightbox — own focus trap so Escape closes it first */}
-      {preview && (
+      {preview && ReactDOM.createPortal(
         <div
           ref={lightboxRef}
           role="dialog"
@@ -423,10 +406,11 @@ export default function PayslipImportModal({ onClose }: { onClose: () => void })
               </div>
             )}
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
-    </div>
+    </>
   );
 
-  return ReactDOM.createPortal(content, document.body);
+  return content;
 }

--- a/src/components/ui/ModalShell.tsx
+++ b/src/components/ui/ModalShell.tsx
@@ -1,0 +1,71 @@
+import { useId, type ReactNode, type RefObject } from 'react';
+import ReactDOM from 'react-dom';
+import { X } from 'lucide-react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+
+interface ModalShellProps {
+  title: string;
+  onClose: () => void;
+  /** aria-label for the header X button; omit to render no X (e.g. ConfirmModal). */
+  closeLabel?: string;
+  /** Optional leading icon in the header row. */
+  icon?: ReactNode;
+  /** Per-modal panel classes: width (sm:min-w/max-w), spacing (space-y-*), scroll (max-h/overflow/flex-col). */
+  panelClassName: string;
+  /** id of the element that describes the dialog (wired to aria-describedby). */
+  describedBy?: string;
+  /** Element to focus on open; falls back to the first focusable child. */
+  initialFocus?: RefObject<HTMLElement | null>;
+  children: ReactNode;
+  /** Optional action row rendered after the body (outside any scrollable child). */
+  footer?: ReactNode;
+}
+
+/**
+ * The one modal scaffold: portal → dimmed overlay (backdrop-click closes) →
+ * panel with focus trap, dialog semantics and the shared header row. Bodies
+ * and footers stay bespoke per modal; every dialog built on this inherits
+ * Escape-to-close, Tab trapping and focus restore from `useFocusTrap`.
+ */
+export function ModalShell({
+  title, onClose, closeLabel, icon, panelClassName, describedBy, initialFocus, children, footer,
+}: ModalShellProps) {
+  const dialogRef = useFocusTrap<HTMLDivElement>(onClose, initialFocus);
+  const titleId = useId();
+
+  const content = (
+    <div
+      className="fixed inset-0 bg-black/60 z-50 flex items-end sm:items-center justify-center"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={describedBy}
+        className={`w-full sm:w-auto bg-[var(--bg-card)] rounded-t-[8px] sm:rounded-[8px] p-6 border border-[var(--border)] ${panelClassName}`}
+      >
+        <div className={`flex items-center shrink-0 ${closeLabel ? 'justify-between' : 'gap-3'}`}>
+          <div className="flex items-center gap-2 min-w-0">
+            {icon}
+            <h3 id={titleId} className="text-[14px] font-semibold text-[var(--text-1)]">{title}</h3>
+          </div>
+          {closeLabel && (
+            <button
+              onClick={onClose}
+              aria-label={closeLabel}
+              className="p-1 rounded-md text-[var(--text-2)] hover:text-[var(--text-1)] hover:bg-[var(--bg-elev)] transition-colors"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+        {children}
+        {footer}
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(content, document.body);
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,3 +4,4 @@ export { DeltaChip } from './DeltaChip';
 export { Sparkline } from './Sparkline';
 export { Button } from './Button';
 export { ProvenanceBadge } from './ProvenanceBadge';
+export { ModalShell } from './ModalShell';


### PR DESCRIPTION
## Why

Audit finding 8.1: EditModal, ConfirmModal, PayslipImportModal and NetWorthHistoryModal each hand-rolled the identical modal stack (portal, dimmed overlay with backdrop-click close, panel chrome, header row + X). The a11y drift this predicted had already happened: NetWorthHistoryModal shipped with no focus trap, no role="dialog" and no aria-modal, only a hand-rolled window Escape listener.

## What

- New `ui/ModalShell` (title, onClose, closeLabel, icon, describedBy, initialFocus, children, footer) owns the portal, overlay, focus trap, dialog semantics and header. Bodies and footers stay bespoke per modal; per-modal sizing/spacing/scroll classes pass through `panelClassName`.
- All four modals are rewritten on the shell; NetWorthHistoryModal thereby gains the missing trap and dialog semantics.
- The payslip preview lightbox moves to its own portal as a sibling tree with its own trap, preserving the Escape-closes-preview-first behavior.
- Net: 144 insertions, 138 deletions, and every future modal (onboarding is growing) inherits correct behavior for free.

Tiny intentional convergences: the X-button hover radius unifies on rounded-md, and ConfirmModal's icon-title gap goes from gap-3 to the shared gap-2.

## Verification

- `npx tsc -b && npm run lint && npm test` green (350 tests).
- Docker build plus a demo-mode browser pass opening all four modals: each exposes a proper dialog in the accessibility tree, initial focus lands correctly (first input in EditModal, cancel in ConfirmModal), Escape and cancel both close, 0 console errors.