### PR TITLE
One ProgressBar for the eleven hand-rolled progress bars

### DIFF
--- a/src/components/CategoryBreakdown.tsx
+++ b/src/components/CategoryBreakdown.tsx
@@ -7,6 +7,7 @@ import { CHART } from '../lib/chartColors';
 import { categoryMoM } from '../lib/categoryStats';
 import { txDisplayName } from '../lib/labelRules';
 import { DeltaChip } from './ui/DeltaChip';
+import { ProgressBar } from './ui/ProgressBar';
 
 // Category dashboard for the selected month: spend per category with icon +
 // colour + share bar, a month-over-month chip, and click-to-drill into the
@@ -86,9 +87,7 @@ export function CategoryBreakdown({ onEditTransaction }: { onEditTransaction?: (
                 </span>
                 <span className="font-mono text-[var(--text-2)] tabular-nums shrink-0">{formatCurrency(r.current)}</span>
               </div>
-              <div className="h-1.5 rounded-[3px] bg-[var(--bg-raised)] overflow-hidden ml-[27px]">
-                <div className="h-full rounded-[3px]" style={{ width: `${pct}%`, background: color(r.category) }} />
-              </div>
+              <ProgressBar pct={pct} heightClass="h-1.5" square trackColor="var(--bg-raised)" color={color(r.category)} className="ml-[27px]" />
             </button>
 
             {isOpen && (

--- a/src/components/CategoryBudgets.tsx
+++ b/src/components/CategoryBudgets.tsx
@@ -7,6 +7,7 @@ import { budgetProgress } from '../lib/categoryStats';
 import { parseLocaleNumber } from '../lib/validators';
 import { SectionLabel } from './ui/SectionLabel';
 import { Button } from './ui/Button';
+import { ProgressBar } from './ui/ProgressBar';
 
 // Per-category monthly budgets: progress bars (actual vs cap) for the selected
 // month with over-budget warnings, plus an inline editor to set/clear caps.
@@ -93,12 +94,7 @@ export function CategoryBudgets() {
                     {formatCurrency(p.spent)} / {formatCurrency(p.budget)}
                   </span>
                 </div>
-                <div className="h-1.5 rounded-[3px] bg-[var(--bg-raised)] overflow-hidden">
-                  <div
-                    className="h-full rounded-[3px]"
-                    style={{ width: `${barPct}%`, background: p.over ? 'var(--negative)' : meta.color }}
-                  />
-                </div>
+                <ProgressBar pct={barPct} heightClass="h-1.5" square trackColor="var(--bg-raised)" color={p.over ? 'var(--negative)' : meta.color} />
                 <div className="text-[11px] tabular-nums" style={{ color: p.over ? 'var(--negative)' : 'var(--text-3)' }}>
                   {p.over
                     ? `${t.overBudgetBy} ${formatCurrency(p.spent - p.budget)}`

--- a/src/components/FunBudget.tsx
+++ b/src/components/FunBudget.tsx
@@ -1,5 +1,6 @@
 import { Smile } from 'lucide-react';
 import { useFinance } from '../context/FinanceContext';
+import { ProgressBar } from './ui/ProgressBar';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
@@ -68,16 +69,11 @@ export default function FunBudget() {
       </div>
 
       <div className="mt-5 space-y-1.5">
-        <div className="h-3 bg-[var(--bg-elev)] rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all duration-700 ${
-              pct >= 100 ? 'bg-[var(--negative)]' :
-              pct >= 75 ? 'bg-[var(--brass)]' :
-              'bg-[var(--positive)]'
-            }`}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
+        <ProgressBar
+          pct={pct}
+          heightClass="h-3"
+          color={pct >= 100 ? 'var(--negative)' : pct >= 75 ? 'var(--brass)' : 'var(--positive)'}
+        />
         <div className="flex justify-between text-[10px] text-[var(--text-2)]">
           <span>0</span>
           <span>{Math.round(pct)}% {t.common.used}</span>

--- a/src/components/GoalsSection.tsx
+++ b/src/components/GoalsSection.tsx
@@ -4,6 +4,7 @@ import { useFinance, type Goal, type GoalSource, type Assets } from '../context/
 import EditModal, { type ModalField } from '../components/EditModal';
 import ConfirmModal from '../components/ConfirmModal';
 import { sumSavings } from '../lib/equity';
+import { ProgressBar } from './ui/ProgressBar';
 import { isValidYearMonth, isOptionalYearMonth, isPositiveNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
@@ -197,15 +198,7 @@ const GoalsSection: React.FC = () => {
                     </button>
                   </div>
                 </div>
-                <div className="h-2 rounded-[3px] overflow-hidden" style={{ background: 'var(--bg-elev)' }}>
-                  <div
-                    className="h-full rounded-[3px] transition-all duration-700"
-                    style={{
-                      width: `${progress}%`,
-                      background: barColor,
-                    }}
-                  />
-                </div>
+                <ProgressBar pct={progress} square color={barColor} />
                 <div className="flex justify-between text-[11px] font-mono" style={{ color: 'var(--text-2)' }}>
                   <span>{formatCurrency(current)}</span>
                   <span>

--- a/src/components/SmartRecommendations.tsx
+++ b/src/components/SmartRecommendations.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { AlertTriangle, TrendingUp, Edit2 } from 'lucide-react';
 import { useFinance } from '../context/FinanceContext';
 import { parseLocaleNumber } from '../lib/validators';
+import { ProgressBar } from './ui/ProgressBar';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
@@ -240,15 +241,11 @@ export default function SmartRecommendations() {
               <span>{t.common.spent}: {formatCurrency(totalSpentThisMonth)}</span>
               <span>{Math.round(spendingPct)}% {t.spentOfRecommended}</span>
             </div>
-            <div className="h-2 bg-[var(--bg-elev)] rounded-[3px] overflow-hidden">
-              <div
-                className={`h-full rounded-[3px] transition-all duration-500 ${
-                  spendingPct >= 100 ? 'bg-[var(--rust)]' :
-                  spendingPct >= 80 ? 'bg-[var(--brass)]' : 'bg-[var(--forest-light)]'
-                }`}
-                style={{ width: `${Math.min(spendingPct, 100)}%` }}
-              />
-            </div>
+            <ProgressBar
+              pct={spendingPct}
+              square
+              color={spendingPct >= 100 ? 'var(--rust)' : spendingPct >= 80 ? 'var(--brass)' : 'var(--forest-light)'}
+            />
           </div>
         </div>
 

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -10,6 +10,7 @@ import {
 import { useFinance, type Assets, type Pension, type Language, type Region, type ExpenseType, type DebtType } from '../../context/FinanceContext';
 import { DEBT_TYPES } from '../../lib/debt';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { ProgressBar } from '../ui/ProgressBar';
 import { parseLocaleNumber } from '../../lib/validators';
 import {
   ONBOARDING_TOPICS,
@@ -212,9 +213,7 @@ function StepView({ topic, copy, step, total, isLast, onBack, onNext, onClose }:
       </div>
 
       {/* Progress bar */}
-      <div className="h-1 rounded-full mb-4 overflow-hidden" style={{ background: 'var(--bg-raised)' }}>
-        <div className="h-full rounded-full transition-[width] duration-300" style={{ width: `${(step / total) * 100}%`, background: 'var(--brass)' }} />
-      </div>
+      <ProgressBar pct={(step / total) * 100} heightClass="h-1" trackColor="var(--bg-raised)" color="var(--brass)" className="mb-4" />
 
       <div className="flex items-center gap-2.5 mb-2">
         <span className="grid place-items-center w-8 h-8 rounded-[6px] shrink-0" style={{ background: 'var(--warning-bg)', color: 'var(--brass)' }}>

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,33 @@
+interface ProgressBarProps {
+  /** Fill percentage. Clamped to [0, 100] here; NaN/Infinity render as 0. */
+  pct: number;
+  /** CSS colour for the fill (`var(--…)` or a CHART hex). */
+  color: string;
+  /** Tailwind height class, e.g. 'h-1.5' | 'h-2' | 'h-3'. */
+  heightClass?: string;
+  /** CSS colour for the track. */
+  trackColor?: string;
+  /** Square-ish 3px corners (category/goal lists) instead of pill ends. */
+  square?: boolean;
+  className?: string;
+}
+
+/**
+ * The one horizontal progress bar. Clamping (and the NaN guard) lives here so
+ * no caller can leak an overflowing or non-finite width into the render — the
+ * money-math bug class CLAUDE.md warns about.
+ */
+export function ProgressBar({
+  pct, color, heightClass = 'h-2', trackColor = 'var(--bg-elev)', square = false, className = '',
+}: ProgressBarProps) {
+  const width = Number.isFinite(pct) ? Math.min(100, Math.max(0, pct)) : 0;
+  const radius = square ? 'rounded-[3px]' : 'rounded-full';
+  return (
+    <div className={`${heightClass} ${radius} overflow-hidden ${className}`} style={{ background: trackColor }}>
+      <div
+        className={`h-full ${radius} transition-[width] duration-300`}
+        style={{ width: `${width}%`, background: color }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,3 +5,4 @@ export { Sparkline } from './Sparkline';
 export { Button } from './Button';
 export { ProvenanceBadge } from './ProvenanceBadge';
 export { ModalShell } from './ModalShell';
+export { ProgressBar } from './ProgressBar';

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -28,6 +28,7 @@ import { sumLedgerSpent } from '../lib/spentTotals';
 import { formatSignedPct } from '../lib/format';
 import { CHART } from '../lib/chartColors';
 import { CategoryBreakdown } from '../components/CategoryBreakdown';
+import { ProgressBar } from '../components/ui/ProgressBar';
 import CategoryTrendChart from '../components/charts/CategoryTrendChart';
 import { CategoryBudgets } from '../components/CategoryBudgets';
 import { MonthlyAccountSpend } from '../components/MonthlyAccountSpend';
@@ -81,9 +82,7 @@ function EnvelopeBar({ envelope, formatCurrency, labels }: {
   const pct = envelope.budgeted > 0 ? Math.min(100, (envelope.actual / envelope.budgeted) * 100) : 0;
   return (
     <div className="mt-2 pl-[15px] space-y-1">
-      <div className="h-[3px] rounded-full bg-[var(--bg-elev)] overflow-hidden">
-        <div className="h-full rounded-full transition-[width]" style={{ width: `${pct}%`, background: color }} />
-      </div>
+      <ProgressBar pct={pct} heightClass="h-[3px]" color={color} />
       <div className="flex items-center justify-between text-[11px] font-mono text-[var(--text-2)]">
         <span>{formatCurrency(envelope.actual)} / {formatCurrency(envelope.budgeted)}</span>
         <span style={{ color }}>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { DeltaChip } from '../components/ui/DeltaChip';
 import { AccountBadge } from '../components/AccountBadge';
 import { txDisplayName } from '../lib/labelRules';
 import { EquityCompositionBar } from '../components/EquityCompositionBar';
+import { ProgressBar } from '../components/ui/ProgressBar';
 import NetWorthHistoryModal from '../components/NetWorthHistoryModal';
 import {
   calcNetWorthProjectionByBucket, calcHouseEquityByYear,
@@ -826,17 +827,13 @@ const DashboardPage: React.FC = () => {
 
           {grossAnnualIncome > 0 && (
             <>
-              <div className="mt-4 h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-elev)' }}>
-                <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${Math.min(100, (debtToIncome.ratio / debtToIncome.cap) * 100)}%`,
-                    background: debtToIncome.status === 'high'
-                      ? 'var(--negative)'
-                      : debtToIncome.status === 'moderate' ? 'var(--warning)' : 'var(--positive)',
-                  }}
-                />
-              </div>
+              <ProgressBar
+                pct={(debtToIncome.ratio / debtToIncome.cap) * 100}
+                color={debtToIncome.status === 'high'
+                  ? 'var(--negative)'
+                  : debtToIncome.status === 'moderate' ? 'var(--warning)' : 'var(--positive)'}
+                className="mt-4"
+              />
               <div className="mt-2 text-[11px]" style={{ color: 'var(--text-3)' }}>
                 {debtToIncome.status === 'high'
                   ? t.dashboardPage.aboveCapText

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -38,6 +38,7 @@ import EditModal, { type ModalField } from '../components/EditModal';
 import ChartTooltip from '../components/ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
+import { ProgressBar } from '../components/ui/ProgressBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import { computeEquityBreakdown, sumSavings } from '../lib/equity';
 import {
@@ -525,12 +526,7 @@ const LoanPage: React.FC = () => {
                       {((houseEquity / assets.houseValue) * 100).toFixed(1)}%
                     </span>
                   </div>
-                  <div className="h-2 rounded-full bg-[var(--bg-elev)] overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-[var(--positive)] transition-all"
-                      style={{ width: `${Math.min(100, Math.max(0, (houseEquity / assets.houseValue) * 100))}%` }}
-                    />
-                  </div>
+                  <ProgressBar pct={(houseEquity / assets.houseValue) * 100} color="var(--positive)" />
                 </div>
               )}
               {assets.houseValue > 0 && homeowner.originalLoanAmount > 0 && (
@@ -541,12 +537,7 @@ const LoanPage: React.FC = () => {
                       {homeownerStatus.equityPercent.toFixed(1)}%
                     </span>
                   </div>
-                  <div className="h-2 rounded-full bg-[var(--bg-elev)] overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-[var(--positive)] transition-all"
-                      style={{ width: `${Math.min(100, homeownerStatus.equityPercent)}%` }}
-                    />
-                  </div>
+                  <ProgressBar pct={homeownerStatus.equityPercent} color="var(--positive)" />
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Why

Audit finding 8.6: the horizontal progress bar was hand-rolled in eleven places with inconsistent clamping — some `Math.min(100, ...)` inline, some pre-clamped upstream, some relying entirely on the caller. That is exactly the NaN/overflow-in-render class the repo guidelines call the highest-risk bug class.

## What

- New `ui/ProgressBar` (pct, color, heightClass?, trackColor?, square?, className?) clamps to [0, 100] internally and renders NaN/Infinity as a 0-width fill, so no caller can leak a bad width into the DOM again.
- All eleven sites move onto it: the Budget envelope bar, CategoryBudgets, CategoryBreakdown, GoalsSection, FunBudget, SmartRecommendations, the onboarding step bar, both LoanPage equity bars and the Dashboard debt-to-income bar. Threshold colours, heights, tracks and corner styles stay per-site as props.
- Transitions unify on width/300ms (previously a mix of none, 300, 500 and 700ms).
- The segmented bars (EquityCompositionBar, LiquidLockedBar) are a different shape and are deliberately untouched.

Also assessed 8.8 (shared EditableRow for AssetRow/SavingsAccountRow/LoanRow) and recommend dropping it: beyond the wrapper class string the three rows share almost nothing — LoanRow has its own highlight/calculated colour logic and notes, SavingsAccountRow uses real buttons for accessibility — so a slot component would be a bigger abstraction than the duplication it removes. Left open in IMPROVEMENTS.md pending your call.

## Verification

- `npx tsc -b && npm run lint && npm test` green (350 tests); repo-wide grep confirms no hand-rolled `h-full rounded` fill divs remain outside the primitive.
- Docker build plus a browser pass over Dashboard and Loan: bars render identically, 0 console errors.