### PR TITLE
SSB inflation: hourly attempt throttle, PxWebApi v2 with v1 fallback

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -122,6 +122,14 @@ const inflationLatest = db.prepare(
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const CACHE_TTL_MS = 30 * ONE_DAY_MS;
+// Upstream-attempt throttle: at most one SSB call per hour, regardless of
+// outcome. Without it, any state that keeps `needsRefresh` true (SSB outage,
+// an API change, or a requested range SSB simply doesn't have) turns EVERY
+// page load into an SSB hit — log spam at best, a block at worst (SSB's
+// limit is 30 req/min/IP). In-memory is fine: one process, and a restart
+// granting one fresh attempt is harmless.
+const SSB_ATTEMPT_COOLDOWN_MS = 60 * 60 * 1000;
+let lastSsbAttemptAt = 0;
 
 function monthCount(fromMonth, toMonth) {
   const [fy, fm] = fromMonth.split('-').map(Number);
@@ -286,7 +294,8 @@ app.get('/api/inflation', async (req, res) => {
   const needsRefresh = cached.length < expectedCount || ageMs > CACHE_TTL_MS;
 
   let stale = false;
-  if (needsRefresh) {
+  if (needsRefresh && Date.now() - lastSsbAttemptAt > SSB_ATTEMPT_COOLDOWN_MS) {
+    lastSsbAttemptAt = Date.now();
     try {
       const points = await fetchCpi(paddedFrom, to);
       const now = new Date().toISOString();
@@ -295,9 +304,13 @@ app.get('/api/inflation', async (req, res) => {
       });
       tx(points);
     } catch (err) {
-      console.warn('[inflation] SSB fetch failed, serving cache:', err.message);
+      console.warn(`[inflation] SSB fetch failed, serving cache (next attempt in ${Math.round(SSB_ATTEMPT_COOLDOWN_MS / 60000)} min):`, err.message);
       stale = true;
     }
+  } else if (needsRefresh) {
+    // Refresh is due but we attempted recently — serve what we have without
+    // touching SSB, flagged stale so the client can show its indicator.
+    stale = true;
   }
 
   const finalRows = inflationGetRange.all(paddedFrom, to);

--- a/server/ssb.d.ts
+++ b/server/ssb.d.ts
@@ -1,0 +1,16 @@
+// Type surface for the CommonJS SSB client (server/ssb.js), so the Vitest
+// tests and any TS consumer get types. Runtime is plain JS.
+export interface CpiPoint {
+  month: string;
+  cpiIndex: number;
+}
+
+export interface CpiPointWithYoy extends CpiPoint {
+  yoyPercent: number | null;
+}
+
+export function fetchCpi(fromMonth: string, toMonth: string): Promise<CpiPoint[]>;
+export function withYoy(points: CpiPoint[]): CpiPointWithYoy[];
+export function monthsInRange(fromMonth: string, toMonth: string): string[];
+export function parseCpiJsonStat2(data: unknown, toMonth: string): CpiPoint[];
+export function buildV2Url(topCount: number): string;

--- a/server/ssb.js
+++ b/server/ssb.js
@@ -2,15 +2,26 @@
  * SSB inflation client — queries Statistics Norway table 03013
  * (Konsumprisindeksen, KPI) and returns { month, cpiIndex, yoyPercent } points.
  *
- * Docs: https://data.ssb.no/api/v0/no/table/03013/
- * Table 03013 dimensions: KonsumKoder (item), Tid (month), ContentsCode (value)
- *   - KonsumKoder = 'TOTAL' for the all-items index
+ * Primary: PxWebApi v2 (GET), launched autumn 2025 —
+ *   https://data.ssb.no/api/pxwebapi/v2/tables/03013/data
+ * Fallback: the classic PxWebApi v1 (POST) while it remains up —
+ *   https://data.ssb.no/api/v0/no/table/03013/
+ * Both return json-stat2, so parsing is shared (and unit-tested).
+ *
+ * SSB rate limit is 30 queries/min per IP — the caller (server/index.js)
+ * additionally throttles upstream attempts so a broken query or an SSB outage
+ * can't turn every page load into an SSB hit.
+ *
+ * Table 03013 dimensions: Konsumgrp (item), Tid (month), ContentsCode (value)
+ *   - Konsumgrp = 'TOTAL' for the all-items index
  *   - ContentsCode = 'KpiIndMnd' for the monthly index (base 2015=100)
  *
  * Node 18+ ships fetch globally; no external HTTP dep needed.
  */
 
-const SSB_URL = 'https://data.ssb.no/api/v0/no/table/03013/';
+const SSB_V2_BASE = 'https://data.ssb.no/api/pxwebapi/v2/tables/03013/data';
+const SSB_V1_URL = 'https://data.ssb.no/api/v0/no/table/03013/';
+const FETCH_TIMEOUT_MS = 10_000;
 
 /**
  * Build the time codes (YYYYMmm) for an inclusive month range.
@@ -35,43 +46,24 @@ function ssbCodeToMonth(code) {
   return `${y}-${m}`;
 }
 
-async function fetchCpi(fromMonth, toMonth) {
-  // Estimate how many months back we need to cover, plus margin.
-  // Use SSB's "top" filter so we don't request months that haven't been
-  // published yet (which would make the entire query 400).
-  const desired = monthsInRange(fromMonth, toMonth).length;
-  const topCount = Math.max(desired + 6, 24);
+/** PxWebApi v2 data URL: GET with valueCodes filters, json-stat2 out. */
+function buildV2Url(topCount) {
+  // Pin all three dimensions so Tid is the only non-singleton one — the
+  // parser relies on that (value[] is then ordered by the Tid index).
+  // Built literally (brackets/parens unencoded) to match SSB's documented
+  // examples exactly; every value here is from a fixed safe alphabet.
+  return `${SSB_V2_BASE}?lang=no&outputFormat=json-stat2`
+    + '&valueCodes[Konsumgrp]=TOTAL'
+    + '&valueCodes[ContentsCode]=KpiIndMnd'
+    + `&valueCodes[Tid]=top(${Math.floor(topCount)})`;
+}
 
-  const body = {
-    query: [
-      {
-        code: 'Konsumgrp',
-        selection: { filter: 'item', values: ['TOTAL'] },
-      },
-      {
-        code: 'Tid',
-        selection: { filter: 'top', values: [String(topCount)] },
-      },
-    ],
-    response: { format: 'json-stat2' },
-  };
-
-  const res = await fetch(SSB_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify(body),
-    // Bound the upstream call so a black-holed connection can't hang
-    // /api/inflation for minutes — the caller falls back to cached data.
-    signal: AbortSignal.timeout(10_000),
-  });
-
-  if (!res.ok) {
-    throw new Error(`SSB returned ${res.status}: ${await res.text()}`);
-  }
-
-  const data = await res.json();
-  // json-stat2: data.value[] is a flat array; dimensions describe layout.
-  // With one item ('TOTAL') and N time codes, value is ordered by Tid index.
+/**
+ * Parse a json-stat2 KPI response (v1 and v2 share the format) into
+ * { month, cpiIndex } points, trimmed to `toMonth`. Assumes Tid is the only
+ * dimension with more than one value, so value[] is ordered by the Tid index.
+ */
+function parseCpiJsonStat2(data, toMonth) {
   const timeDim = data.dimension?.Tid;
   if (!timeDim) throw new Error('SSB response missing Tid dimension');
 
@@ -90,6 +82,51 @@ async function fetchCpi(fromMonth, toMonth) {
   return points.filter(p => p.month <= toMonth);
 }
 
+async function fetchJson(url, init) {
+  const res = await fetch(url, {
+    ...init,
+    // Bound the upstream call so a black-holed connection can't hang
+    // /api/inflation for long — the caller falls back to cached data.
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`SSB returned ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function fetchCpi(fromMonth, toMonth) {
+  // Estimate how many months back we need to cover, plus margin.
+  // "top" counts from the newest published month, so we never request months
+  // that don't exist yet (which would make a code-list query 400).
+  const desired = monthsInRange(fromMonth, toMonth).length;
+  const topCount = Math.max(desired + 6, 24);
+
+  try {
+    const data = await fetchJson(buildV2Url(topCount), { headers: { Accept: 'application/json' } });
+    return parseCpiJsonStat2(data, toMonth);
+  } catch (v2Err) {
+    // v1 stays up "during a transition period" (SSB) — try it before giving up.
+    const body = {
+      query: [
+        { code: 'Konsumgrp', selection: { filter: 'item', values: ['TOTAL'] } },
+        { code: 'Tid', selection: { filter: 'top', values: [String(topCount)] } },
+      ],
+      response: { format: 'json-stat2' },
+    };
+    try {
+      const data = await fetchJson(SSB_V1_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return parseCpiJsonStat2(data, toMonth);
+    } catch (v1Err) {
+      throw new Error(`v2: ${v2Err.message}; v1: ${v1Err.message}`);
+    }
+  }
+}
+
 /**
  * Compute year-over-year % change for each point given a full series
  * (which must include the 12 prior months for the YoY to be defined).
@@ -105,4 +142,4 @@ function withYoy(points) {
   });
 }
 
-module.exports = { fetchCpi, withYoy, monthsInRange };
+module.exports = { fetchCpi, withYoy, monthsInRange, parseCpiJsonStat2, buildV2Url };

--- a/src/lib/ssb.test.ts
+++ b/src/lib/ssb.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+// The SSB client lives in the CommonJS server engine (server/ssb.js) so it
+// ships in the production image; its pure parts are tested here via Vitest.
+import { parseCpiJsonStat2, buildV2Url, withYoy, monthsInRange } from '../../server/ssb.js';
+
+// Minimal json-stat2 shape shared by PxWebApi v1 and v2 for this query:
+// Konsumgrp and ContentsCode pinned to one value, Tid the only real dimension.
+const jsonStat2 = (index: Record<string, number>, value: (number | null)[]) => ({
+  dimension: {
+    Konsumgrp: { category: { index: { TOTAL: 0 } } },
+    ContentsCode: { category: { index: { KpiIndMnd: 0 } } },
+    Tid: { category: { index } },
+  },
+  value,
+});
+
+describe('parseCpiJsonStat2', () => {
+  it('maps Tid codes to sorted { month, cpiIndex } points', () => {
+    const data = jsonStat2({ '2026M05': 0, '2026M06': 1, '2026M04': 2 }, [138.1, 138.4, 137.9]);
+    expect(parseCpiJsonStat2(data, '2026-06')).toEqual([
+      { month: '2026-04', cpiIndex: 137.9 },
+      { month: '2026-05', cpiIndex: 138.1 },
+      { month: '2026-06', cpiIndex: 138.4 },
+    ]);
+  });
+
+  it('trims months past the requested upper bound', () => {
+    const data = jsonStat2({ '2026M06': 0, '2026M07': 1 }, [138.4, 138.6]);
+    expect(parseCpiJsonStat2(data, '2026-06')).toEqual([{ month: '2026-06', cpiIndex: 138.4 }]);
+  });
+
+  it('skips null values (unpublished months) instead of emitting NaN', () => {
+    const data = jsonStat2({ '2026M05': 0, '2026M06': 1 }, [138.1, null]);
+    expect(parseCpiJsonStat2(data, '2026-06')).toEqual([{ month: '2026-05', cpiIndex: 138.1 }]);
+  });
+
+  it('throws on a response without the Tid dimension', () => {
+    expect(() => parseCpiJsonStat2({ dimension: {} }, '2026-06')).toThrow(/Tid/);
+  });
+});
+
+describe('buildV2Url', () => {
+  it('pins all three dimensions and uses top() time selection, unencoded', () => {
+    const url = buildV2Url(24);
+    expect(url).toBe(
+      'https://data.ssb.no/api/pxwebapi/v2/tables/03013/data?lang=no&outputFormat=json-stat2'
+      + '&valueCodes[Konsumgrp]=TOTAL&valueCodes[ContentsCode]=KpiIndMnd&valueCodes[Tid]=top(24)',
+    );
+  });
+});
+
+describe('withYoy', () => {
+  it('computes YoY against the month 12 back, null when missing', () => {
+    const points = [
+      { month: '2025-06', cpiIndex: 132.0 },
+      { month: '2026-06', cpiIndex: 138.6 },
+    ];
+    const out = withYoy(points);
+    expect(out[0].yoyPercent).toBeNull();
+    expect(out[1].yoyPercent).toBeCloseTo(5.0, 5);
+  });
+});
+
+describe('monthsInRange', () => {
+  it('spans year boundaries inclusively in SSB code format', () => {
+    expect(monthsInRange('2025-11', '2026-02')).toEqual(['2025M11', '2025M12', '2026M01', '2026M02']);
+  });
+});


### PR DESCRIPTION
## Why

Homelab logs filled with `[inflation] SSB fetch failed, serving cache: SSB returned 400: {"error":"Parameter error"}` — one line (and one SSB hit) per page load. Two distinct problems:

1. **No failure backoff.** `needsRefresh` derives from cache completeness and TTL; a failed fetch changes neither, so every `/api/inflation` request retried SSB and hung up to 10s doing it. The same held for any requested range SSB cannot fully satisfy, even after successful fetches. SSB's documented limit is 30 requests/min per IP, so a broken query plus a few open tabs is genuinely in blockable territory.
2. **The API generation is turning over.** SSB launched PxWebApi v2 in autumn 2025 and the classic `api/v0` currently answers even bare metadata GETs with "Parameter error". (During this work SSB's data API was fully down: v2 returned 503 "Backend fetch failed" too.)

## What

- **Throttle:** at most one upstream attempt per hour regardless of outcome (in-memory timestamp — one process, and a restart granting one fresh attempt is harmless). Worst case drops from one SSB call per page load to ~48/day. Only the first request after a cooldown can block on SSB; everything else serves the cache instantly with `stale: true`, so the client indicator still works. The log line now says when the next attempt happens.
- **v2 first, v1 fallback:** `fetchCpi` queries PxWebApi v2 via GET (`valueCodes[Konsumgrp]=TOTAL`, `valueCodes[ContentsCode]=KpiIndMnd`, `valueCodes[Tid]=top(n)`, json-stat2), falling back to the old v1 POST while SSB keeps it up during the transition. Parsing is shared (same json-stat2 shape), extracted pure, and unit-tested; `server/ssb.d.ts` mirrors the `bank.d.ts` pattern.

## Verification

- `npx tsc -b && npm run lint && npm test` green (357 tests, 7 new: parsing, trimming, null months, v2 URL shape, YoY, month ranges).
- Throwaway-`DATA_DIR` server and the live local instance: first request attempts SSB once (both API versions fail fast while SSB is down), subsequent requests return in ~10ms from cache with one log line total.
- Caveat: SSB's API was down end-to-end during development, so the v2 query is built strictly from SSB's documented examples and verified at the URL/parse level; the v1 fallback preserves today's (previously working) query untouched. Once SSB recovers, the next hourly attempt refreshes the cache with no further action.