### PR TITLE
refactor: cashflow/pension/salary lib extractions + makeCrud (IMPROVEMENTS 8.5, 5.1, 8.4)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -501,7 +501,12 @@ blocks with hardcoded `#262A20`/`#5F6555`, the old hex twins of the same tokens)
 export `AXIS_PROPS` / `AXIS_PROPS_Y` / `GRID_PROPS` from `src/lib/chartColors.ts` (already
 imported everywhere) and spread them; this also closes most of 5.5's SVG-context hex list.
 
-**8.4 🟡 FinanceContext CRUD triple × 7 entities.**
+**8.4 ✅ FINISHED (f0d620a) FinanceContext CRUD triple × 7 entities.**
+(`makeCrud<T>(setter, prefix)` → `{ add, update, remove }` at module level; jobs, salaries,
+bonuses, overtime, hoursSnapshots, goals each bind it once via `useMemo` for stable action
+identity, and savingsAccounts reuses it through a setAssets adapter. `add` always returns the
+id; `removeJob`'s salary cascade and `addSavingsAccount`'s `(name, balance)` signature are
+preserved. ~65 lines → ~30.)
 `FinanceContext.tsx:1518-1582` (jobs, salaries, bonuses, overtime, hoursSnapshots, goals)
 plus savingsAccounts at :1442-1459 repeat the identical add/update/remove shape
 (`[...prev, {...entry, id: makeId(pfx)}]` / `map(x => x.id === id ? {...x, ...patch} : x)` /

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -273,22 +273,25 @@ Row percentages divide by unclamped `totalEquity` while rows clamp to ≥0 (can 
 
 ## 5. Legacy & hacky code to clean up
 
-**5.1 🟡 Inline financial maths that belongs in `src/lib/` with tests.**
-- Pension projection compounding duplicated in `PensionPage.tsx:51-68` (iterative) and
-  `ForecastPage.tsx:48-55` (closed form). They agree today (verified); extract one
-  `projectPensionWealth()` before they drift.
-- `ForecastPage.tsx:83-90` re-implements the annuity formula annually, giving slightly
-  different totals than the shared monthly `calcMonthlyPayment` used elsewhere.
-- `LoanPage.tsx:185-201` re-implements year-one interest (duplicates
-  `calcAmortizationSchedule`) and computes `totalInterest` that goes negative when
-  `nedbetalingstid = 0` (allowed by the editor).
-- `DashboardPage.tsx:185,1106,1113` unlabeled assumptions: `1.02 ** i` (2%/month growth,
-  twice), `max * 0.85` target line.
-- `SalaryPage.tsx:53,153,184-203` `WEEKS_PER_MONTH = 4.345` and the hourly/trailing-12
-  aggregation, untested inline. Related lib gap: `hoursAt` (`src/lib/salary.ts`) picks the
-  latest snapshot with no `jobId` filter and the page passes all snapshots
-  (`SalaryPage.tsx:146`), so a snapshot from an ended job leaks into later jobs' hourly
-  maths.
+**5.1 🟡 Inline financial maths that belongs in `src/lib/` with tests.** (mostly closed in 7e4d8b9)
+- ✅ FINISHED (7e4d8b9) Pension projection compounding duplicated in `PensionPage.tsx`
+  (iterative) and `ForecastPage.tsx` (closed form). Extracted to `src/lib/pension.ts`
+  (`pensionFutureValue` + `projectPensionWealth`, tested); both pages consume it.
+- ✅ FINISHED (7e4d8b9) `ForecastPage.tsx` re-implemented the annuity formula annually; now
+  `annualMortgagePayment = 12 × calcMonthlyPayment(...)`, matching the Loan page.
+- ✅ FINISHED (7e4d8b9) `LoanPage.tsx` re-implemented year-one interest and computed a
+  `totalInterest` that went negative at `nedbetalingstid = 0`. Both now derive from
+  `calcAmortizationSchedule` (year-one = `schedule[0].interestPaid`, total = sum of
+  `interestPaid`), so a 0-term loan reports 0 interest.
+- ✅ FINISHED (7e4d8b9) `DashboardPage` `1.02 ** i` / `max * 0.85` are now the named
+  `PROJECTED_INCOME_GROWTH` / `INCOME_TARGET_SHARE` constants.
+- ✅ FINISHED (7e4d8b9) the `hoursAt` `jobId` leak — a snapshot assigned to one job no longer
+  leaks into another job's hourly maths (unassigned snapshots stay global); `WEEKS_PER_MONTH`
+  and the per-month `nominalHourlyRate` moved to `src/lib/salary.ts` with tests.
+- 🟢 Residual: `SalaryPage.tsx` `trailingHourly` (trailing-12 hourly incl. bonus/overtime/
+  on-call) is still an inline page-level aggregation. Extract to a tested lib helper when it
+  next needs touching; it composes `series` + `bonuses` + `overtime`, so it's page-shaped
+  rather than a shared formula.
 
 **5.2 ✅ FINISHED (e7747e8) `parseFloat` where `parseLocaleNumber` is mandated.**
 Beyond 1.6: `PensionPage.tsx:303`, `EmployerCostPage.tsx:108,186,280`,

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,611 @@
+# Headroom, maths & value-population audit (2026-07-07)
+
+Full pass over how every number is computed and how values flow into charts, tables and tiles,
+motivated by the app being shared (friends now self-host their own instances, each
+single-user). Covered:
+all of `src/lib/` plus tests, all pages, all chart/section components, `FinanceContext.tsx`,
+and the server (`index.js`, `bank.js`, `seed.js`, `ssb.js`).
+
+This follows up `AUDIT.md` (2026-07-04, closed out). Items already tracked in `BACKLOG.md`
+are cross-referenced, not re-opened, except where this audit changes their urgency or
+resolves their open question. The HIGH findings below were spot-verified against the code
+before publishing.
+
+Severity: 🔴 high (a wrong number is shown to the user, or data is at risk) ·
+🟡 medium (edge-case wrong value, crash, or drift risk) · 🟢 low (hygiene, tests, style) ·
+✅ FINISHED (fixed on main, commit in parentheses).
+
+Each item is written to be self-contained: file and line refs, the failing scenario, and the
+intended fix, so any item can be picked up fresh without this document's history. Line
+numbers are as of commit 4813878. For every fix, the repo gate applies:
+`npx tsc -b && npm run lint && npm test`, plus `make build` and a browser smoke test for
+UI-visible changes (mind the service-worker cache gotcha in CLAUDE.md). Pure-math fixes
+should land together with a unit test in the same `src/lib/*.test.ts`.
+
+---
+
+## 1. Wrong numbers on screen (fix first)
+
+**1.1 ✅ FINISHED (09cedf5) Trygdeavgift rate is the 2024 value; every take-home figure is overstated.**
+`TAX_PARAMS[2025].trygdeavgiftRate` is `0.078`, but the 2025 statutory rate on wage income
+is 7.7% (cut 0.1pp in the 2025 budget). Every other 2025 constant in the table checks out
+(personfradrag 108 550, minstefradrag 46%/92 000, all trinnskatt brackets). This resolves
+the open question in `BACKLOG.md` ("Math-correctness audit, deferred findings"): the answer
+is 7.7. At a 744 000 gross the shown tax is 744 kr/yr too high, flowing into net monthly,
+effective rate, budget income, and the forecast.
+Fix: `trygdeavgiftRate: 0.077` in `src/lib/norwegianTax.ts:32`.
+
+**1.2 ✅ FINISHED (09cedf5) No 2026 tax year exists, and it is July 2026.**
+`TAX_YEAR = 2025` with no `TAX_PARAMS[2026]` entry, so all salary numbers are computed on
+last year's brackets. Meanwhile `src/lib/employerCost.ts` claims 2026 correctness in its
+header, so the two libs disagree about which year the app models.
+Fix: add `TAX_PARAMS[2026]` (trygdeavgift, personfradrag and trinnskatt all changed) and
+bump `TAX_YEAR`. Consider deriving the default year from the current date so this can't
+silently go stale again.
+
+**1.3 ✅ FINISHED (1af9356; residual asymmetry closed 2026-07-08) Dashboard "vs last month" spending chip compares incompatible quantities.**
+*(Re-verified 2026-07-08: 1af9356 fixed the previous-month side but the chip's current-month
+side still came from `dailyData` built on the raw month transactions, so an internal
+transfer's expense leg counted this month and not last month. Closed by adding
+`currentMonthSpending` — `discretionarySpendForMonth` over `nonTransferTransactions`, same
+call as `prevMonthSpending` — and pointing `spendingDelta` at it; `totalSpent` for the
+Budget-Health bar is unchanged.)*
+`spendingDelta` (`src/pages/DashboardPage.tsx:91`) compares this month's discretionary
+spend against `prevMonthSpending` from `FinanceContext.tsx:1167-1171`, which sums *all*
+transactions for the previous month: income deposits included, internal transfers included,
+envelope-covered spend included. For any bank-synced user a salary deposit inflates "last
+month's spending", so the chip percentage is wrong essentially always.
+Fix: compute the previous month with the same pipeline as the current month (exclude
+income/transfers, use discretionary), via one shared helper in `src/lib/`.
+
+**1.4 ✅ FINISHED (1af9356) Loan page "Totalpris" contradicts the row above it.**
+`totalpris = loan.betingetLaan + effEgenkapital` (`src/pages/LoanPage.tsx:207`), where
+`effEgenkapital` is the auto-derived Låneevne equity, but the same card's "Egenkapital" row
+shows `loan.egenkapital` and the note says "Betinget lån + egenkapital". With
+finansieringsbevis equity 500k and derived liquid equity 800k, the card's own rows don't sum
+to its total. Fix: `loan.betingetLaan + loan.egenkapital`.
+
+**1.5 ✅ FINISHED (1af9356, test mock in ddcb039) CashflowChart counts internal transfers as expenses.**
+`src/components/charts/CashflowChart.tsx:20` uses raw `dailyTransactions` while its sibling
+`SavingsRateChart.tsx:18` deliberately uses `nonTransferTransactions`. Moving money between
+your own accounts inflates "money out" and the two charts on the same page disagree.
+Already noted as deferred in `BACKLOG.md` ("Transfer netting is Budget-scoped"); elevating
+because with multi-account bank sync it now corrupts the dashboard for real users.
+Fix: switch `CashflowChart` (and `InsightBanner`) to `nonTransferTransactions`.
+
+**1.6 ✅ FINISHED (1af9356) Raise calculator misparses Norwegian numbers as tiny values.**
+`NextReviewCard` (`src/pages/SalaryPage.tsx:1503-1506`) hand-rolls parsing with `parseFloat`
+instead of the imported `parseLocaleNumber`. Input `"600.000"` parses as 600 and the card
+confidently shows a −99.9% raise. Fix: use `parseLocaleNumber` (returns NaN, which already
+renders as an em dash).
+
+**1.7 ✅ FINISHED (1af9356) Fun budget card is dead for bank-synced users.**
+`src/components/FunBudget.tsx:32-42` matches a fixed expense literally named "fun"/"moro"
+and transactions whose category string equals those words. Canonical categories use
+`entertainment` (`src/lib/categories.ts`), so `funSpent` is permanently 0 with categorized
+data, and the Norwegian magic string violates the app-must-be-generic rule.
+Fix: drive it from a canonical category or an envelope link, not name matching.
+
+**1.8 ✅ FINISHED (0c3921e) Onboarding writes savings into a dead field; the money never appears anywhere.**
+The "cash" onboarding topic defines `{ key: 'savings', writer: 'asset' }`
+(`src/lib/onboarding.ts:113`) and `OnboardingTour.tsx:286` executes it as
+`updateAsset('savings', n)`, the legacy scalar. But `sumSavings` (`src/lib/equity.ts:17`)
+takes the array branch whenever `savingsAccounts` is an array, which it always is: fresh
+users get `DEFAULT_ASSETS.savingsAccounts: []`, and `migrateSavingsAccounts`
+(`FinanceContext.tsx:699-718`, called at :876) only absorbs the scalar when the array is
+*absent*, not when it's empty. Net effect: a friend doing first-run setup types their
+savings and it never shows in net worth, the Assets page, or the Dashboard cash tile; it is
+only visible inside the onboarding field itself. Fix: make the onboarding writer create a
+savings account (`addSavingsAccount`), or make `migrateSavingsAccounts` also absorb a
+nonzero scalar when the array is empty. Highest priority given onboarding is the current
+project goal.
+
+---
+
+## 2. Data safety & persistence
+
+**2.1 ✅ FINISHED (1af9356) Imported backups can put string "numbers" into the maths.**
+`sanitizePayload` (`src/lib/sanitizePayload.ts`) coerces top-level scalars, five schema
+objects and three number-records, but never descends into `fixedExpenses[].amount`,
+`dailyTransactions[].amount`, or `debts[].balance/rate/minPayment`. A hand-edited backup
+with `"amount": "5 000"` passes the Settings import check and the server's shape validation,
+then `totalFixedExpenses` string-concatenates and NaN/garbage flows through `monthlyBudget`,
+`dailyBudget` and every chart, and gets autosaved over good data. This is the repo's own
+stated highest-risk bug class. Fix: coerce the numeric fields of those three arrays (and
+`balanceSnapshots` nested numbers, see 4.6).
+
+**2.2 ✅ FINISHED (fdd75db) Disconnecting and reconnecting a bank duplicates up to 90 days of transactions.**
+`startLink` (`server/bank.js:400-419`) only reuses a connection id if the ASPSP connection
+still exists; after `removeConnection` a re-add mints a new UUID, a new `eb-<conn8>-` id
+prefix and a null `last_sync`, so the full 90-day history re-imports under new ids.
+`mergeTransactions` keys by id and `dropStaleBareTwins` intentionally never merges across
+prefixed connections, so all spending double-counts until the user finds the historical-
+accounts delete button. Fix: on re-add of an ASPSP that has orphaned rows, reuse the old
+prefix (or dedupe by `(entry_reference, aspsp)` at merge time).
+
+**2.3 ✅ FINISHED (1f7b670) The id-format dedup (commit 4813878) never converges server-side.**
+`applyPayload` drops bare twins via raw `setDailyTransactions` without recording the dropped
+ids in `deletedBankIds`. On the next autosave the server's `reconcileBankTransactions`
+(`server/index.js:177-199`) sees stored `eb-` rows missing from the payload and re-adds
+them, every save, forever (the UI stays clean because every read path re-dedupes, but the
+stored blob keeps the dupes and client/server ping-pong on each save). Fix: record dropped
+bare ids into `deletedBankIds` in `applyPayload`, or run `dropStaleBareTwins` in the POST
+handler after reconcile.
+
+**2.4 ✅ FINISHED (d034a9c) "Delete all data" keeps payslips.**
+`resetAll` (`src/context/FinanceContext.tsx:1696-1751`) resets every domain field except
+`payslips`; imported gross/net/tax figures survive a full wipe and are re-persisted by the
+next autosave. Fix: `setPayslips({})`.
+
+**2.5 ✅ FINISHED (b2fb174) Demo mode leaks real data.**
+(a) `getDemoData` (`src/lib/demoData.ts`) omits `accountLabels`, `categoryRules`,
+`labelRules`, `employerCostConfig`, `billingConfig`, despite its own "must set EVERY field
+that can hold personal data" contract; real merchant rules and billing rates render during a
+demo. (b) Bank sync isn't gated on demo mode: "Sync now" during a demo pulls the full real
+ledger into the visible demo state (`BankSyncCard.tsx:199-221`). Disk data stays safe in
+both cases; this is a display leak, which is exactly what demo mode exists to prevent.
+Fix: set the missing fields to empty defaults in the demo payload; hide or disable the bank
+card while `demoMode`.
+
+**2.6 ✅ FINISHED (8abbe85) Server-side wipe protection misses three user-authored fields.**
+`preserveUserFields` (`server/index.js:206-224`) guards `accountLabels` and `categoryRules`
+against a payload from an older client, but not `labelRules`, `categoryBudgets` or
+`deletedBankIds` (whose omission resurrects deleted bank rows). Given the PWA stale-SW
+gotcha, an old cached build posting once is a realistic scenario. Fix: add the three fields.
+
+**2.7 ✅ FINISHED (6424e10) Identical same-day transactions can merge into one row.**
+The `stableId` fallback for feeds without `entry_reference` (`server/bank.js:284-288`) is
+`date|indicator|amount|desc[0..24]`; two genuinely distinct 49 kr purchases at the same
+merchant on the same day collide and spending undercounts. Fix: add an occurrence counter
+within the mapped batch.
+
+---
+
+## 3. Same user, several open clients (two tabs, or laptop + phone PWA)
+
+Each install is single-user (every friend self-hosts their own instance), so there is no
+shared-instance scenario to defend. What remains is one person's own instance open in more
+than one place at once: a second browser tab, or the laptop plus the installed phone PWA.
+The optimistic-concurrency rev system is sound on the main path (verified), but two gaps
+remain where last-write-wins can silently eat that user's own edits:
+
+**3.1 ✅ FINISHED (03fe6c8) The pagehide beacon flush bypasses rev checking.**
+(The related LOW — the beacon can't read a response, so `revRef` stays one behind and the
+return-to-tab reload shows a spurious "data reloaded" banner — remains open.)
+`sendBeacon` can't set the `X-Data-Rev` header, so the server treats the flush as a legacy
+client and takes last-write-wins (`FinanceContext.tsx:1105-1113`, `server/index.js:234-241`).
+Close the laptop tab within the debounce window and its beacon clobbers what the phone (or
+another tab) wrote in between. Fix: carry the rev inside the JSON body (`_rev`) and honor it
+server-side as a header fallback. Related: the beacon also doesn't update `revRef`, causing
+a spurious "data reloaded" banner on return (LOW).
+
+**3.2 ✅ FINISHED (2a54ab8) Merely opening the app dirties the data, making 409 conflicts frequent.**
+(Fixed at both layers: the snapshot effects skip structurally-equal rewrites, and
+doSave/the beacon skip the POST entirely when the payload matches the last content the
+server is known to hold — the snapshot fix alone wouldn't have stopped the on-load save,
+since the autosave effect fires after any `applyPayload`. Merge-on-409 left as-is: with
+no-op saves gone, a 409 only fires on genuine concurrent edits.)
+The net-worth snapshot and balance snapshot effects (`FinanceContext.tsx:1403-1423`) rewrite
+the current-month entries on every load, triggering a POST with no user action. Combined
+with the 409 handler adopting the server version wholesale (discarding local unsaved edits
+with only a banner), opening the app in a second tab or on the phone can eat an in-flight
+edit in the first. Fix: skip the snapshot writes when the value is deep-equal to what's
+stored; consider merging rather than discarding on 409.
+
+---
+
+## 4. Consistency between numbers on different surfaces
+
+**4.1 ✅ FINISHED (cee8c5d) Dashboard hero: headline vs chart/chip track different quantities.**
+(Fixed via the BACKLOG debt-historization item: `netWorthHistory` now records `netWorth`,
+the live chart anchor is `netWorth`, and `calcNetWorthProjectionByBucket` nets a projected
+`debtByYear` so both growth projections start at true net worth. History recorded before
+the change is equity-based and can't be reconstructed — documented in `BACKLOG.md`.)
+The headline shows `netWorth` (equity − debt) but the MoM chip, 12-month change and hero
+chart are built from `netWorthHistory`, which snapshots `totalEquity`
+(`FinanceContext.tsx:1418`, `DashboardPage.tsx:343,354-356`). With any non-mortgage debt the
+chip tracks a larger number than the figure it sits next to. Root cause is already tracked
+in `BACKLOG.md` ("Debts aren't historized or projected"); doing that item fixes this.
+
+**4.2 ✅ FINISHED (6505631) Debt-to-income tile prints a debt figure that doesn't match its ratio.**
+The ratio uses `houseDebt + totalDebt`; the sub-line prints only `houseDebt`
+(`DashboardPage.tsx:95,797`). Fix: print the same sum the ratio uses.
+
+**4.3 ✅ FINISHED (2e6ec70) Dashboard investment bars are built from the manual-override map only.**
+`investmentBars` (`DashboardPage.tsx:164-189`) derives its 12 months from
+`Object.keys(monthlyIncomes)`, dropping months whose income is salary-derived, so the bars
+can be non-contiguous months rendered as contiguous, with "projected" bars extending from a
+stale month. The context's `incomeSeries` (`FinanceContext.tsx:1216-1224`) already builds
+the correct fixed 12-month grid with `monthlyIncomes[m] ?? derivedNetMonthlyFor(m)`
+fallback; build the bars on that.
+
+**4.4 ✅ FINISHED (2e6ec70) Budget Health legend mixes denominators.**
+"Remaining budget" pairs a kr value computed after the savings slice with a percentage
+computed before it, and `spentPct` is clamped so overspend months understate the spent share
+(`DashboardPage.tsx:86-88,513-521`). Fix: one definition for both the kr and % of each
+legend item, unclamped (or explicitly marked when clamped).
+
+**4.5 ✅ FINISHED (cee8c5d) Assets time machine mixes past assets with today's debt.**
+(Fixed the long-term way: `BalanceSnapshot` now carries `debts`, AssetPage history mode uses
+the viewed month's debts — pre-change snapshots render equity-only, matching what history
+recorded then — and the live debt editor is hidden while time-travelling.)
+`AssetPage.tsx:90-93` uses live `totalDebt` (and a fully-live `EquityCompositionBar`) even
+when rendering a historical snapshot; LoanPage gates on `hist.isLive` correctly. Fix: gate
+like LoanPage; long-term, snapshotting debts (the BACKLOG item in 4.1) makes history honest.
+
+**4.6 ✅ FINISHED (616837c) Old balance snapshots can render NaN in the composition chart.**
+`computeEquityBreakdown` does no field guarding and
+`NetWorthCompositionChart.tsx:22` feeds it raw `balanceSnapshots[key]?.assets`; a snapshot
+saved before a field existed (`cryptoUnrealizedGain`, `bufferAccount`, ...) yields
+`undefined * n → NaN` in the bar. `sanitizePayload` also skips snapshot internals (see 2.1).
+Fix: `?? 0` each field inside `computeEquityBreakdown`; cheapest, covers all callers.
+
+**4.7 ✅ FINISHED (e2a27bf) Salary YoY tiles fabricate "+0.0%" with short history.**
+With fewer than 13 months of data, `yoy` returns zeros instead of null, so a new user sees a
+confident flat salary-vs-inflation comparison (`SalaryPage.tsx:164-181,762-786`). Fix:
+return null and render the em dash like the other tiles.
+
+**4.8 ✅ FINISHED (e2a27bf) Future-dated salary entries leak into "current" figures.**
+`currentJob` and the on-call sub-line take the last entry of `sortedSalaries` even when its
+`effectiveDate` is months ahead, while the headline uses `salaryAt` clamped to today
+(`SalaryPage.tsx:696-699,267-269`); the Next-review card baselines against the future raise.
+Fix: use `salaryAt(currentMonthKey, ...)` for all three.
+
+**4.9 ✅ FINISHED (178ccef) Sankey fabricates 1 kr flows.**
+`Math.max(1, ...)` on every link (`MoneyFlowSankey.tsx:74-78`) renders flows for genuinely
+zero buckets and unbalances in vs out by rounding. Fix: drop zero links; round the remainder
+bucket last.
+
+**4.10 ✅ FINISHED (2e6ec70) Two definitions of "spent this month" ship simultaneously.**
+Budget's ledger uses `day.spent` (envelope-covered included, `BudgetPage.tsx:402`),
+Dashboard uses `discretionary` (`DashboardPage.tsx:80`). Each is defensible in place, but
+the same phrase shows different numbers on two pages, and the Budget ledger footer renders
+`totalSpentThisMonth` in a row labeled as surplus (`BudgetPage.tsx:963-974`, the label has
+colSpan 2 and the cell sits under the "Impact" column). Fix: one shared, documented helper
+in `src/lib/`; fix the footer label/cell pairing.
+
+**4.11 ✅ FINISHED (2e6ec70) Asset-allocation percentages use inconsistent denominators.**
+Row percentages divide by unclamped `totalEquity` while rows clamp to ≥0 (can sum past
+100%), and the strip uses a different denominator than the rows
+(`DashboardPage.tsx:560,578`). Fix: one clamped denominator for both.
+
+---
+
+## 5. Legacy & hacky code to clean up
+
+**5.1 🟡 Inline financial maths that belongs in `src/lib/` with tests.**
+- Pension projection compounding duplicated in `PensionPage.tsx:51-68` (iterative) and
+  `ForecastPage.tsx:48-55` (closed form). They agree today (verified); extract one
+  `projectPensionWealth()` before they drift.
+- `ForecastPage.tsx:83-90` re-implements the annuity formula annually, giving slightly
+  different totals than the shared monthly `calcMonthlyPayment` used elsewhere.
+- `LoanPage.tsx:185-201` re-implements year-one interest (duplicates
+  `calcAmortizationSchedule`) and computes `totalInterest` that goes negative when
+  `nedbetalingstid = 0` (allowed by the editor).
+- `DashboardPage.tsx:185,1106,1113` unlabeled assumptions: `1.02 ** i` (2%/month growth,
+  twice), `max * 0.85` target line.
+- `SalaryPage.tsx:53,153,184-203` `WEEKS_PER_MONTH = 4.345` and the hourly/trailing-12
+  aggregation, untested inline. Related lib gap: `hoursAt` (`src/lib/salary.ts`) picks the
+  latest snapshot with no `jobId` filter and the page passes all snapshots
+  (`SalaryPage.tsx:146`), so a snapshot from an ended job leaks into later jobs' hourly
+  maths.
+
+**5.2 ✅ FINISHED (e7747e8) `parseFloat` where `parseLocaleNumber` is mandated.**
+Beyond 1.6: `PensionPage.tsx:303`, `EmployerCostPage.tsx:108,186,280`,
+`SettingsPage.tsx:268,321-327`, `SmartRecommendations.tsx:41,114`,
+`NetWorthHistoryModal.tsx:43`. Mostly `type="number"` inputs so browsers usually sanitize,
+but Firefox passes `"1,5"` through and it commits as 1. One sweep fixes the class.
+
+**5.3 ✅ FINISHED (2ebc757) Hardcoded Norwegian copy despite the i18n migration.**
+(All sites below moved into `src/i18n/translations.ts`; DashboardPage 'MMM' now uses the
+date-fns locale. Verified in the browser in both languages.)
+Largest offender is `LoanPage.tsx` (first-buyer/homeowner sections at lines 334, 337-364,
+375-398, 406-446, 469-599: "Låneevne", "Kostnad på lån", the whole rate-comparison
+paragraph, seller/buyer flow labels; also "Nedbetalt av opprinnelig lån" at :539 and the
+"Nå" label at `ForecastPage.tsx:338`). All strings belong in
+`src/i18n/translations.ts` under the existing `loanPage`/`forecastPage` namespaces. Also
+`BudgetPage.tsx:203-364` validation strings (`' må være et positivt tall'` concatenated onto
+translated labels, so English users get mixed-language errors) and placeholders;
+`SalaryPage.tsx` unit suffixes (`t/uke`, `KPI`) plus English-only `Inflation gap`;
+`PensionPage`/`EmployerCostPage` unit suffixes; untranslated aria-labels in
+`BalanceHistoryBar`; hardcoded "Cancel" in `SettingsPage.tsx:732`; `DashboardPage`
+`'MMM'` formatting without a date-fns locale (English month names in the Norwegian UI,
+BudgetPage does it right).
+
+**5.4 ✅ FINISHED Hardcoded personal/vendor data (app-must-be-generic).**
+- ✅ FINISHED (8c1264e) `server/bank.js:10`: a real Enable Banking APP_ID UUID as the code
+  default; EB_APP_ID is now required config (deploys relying on the old default must set it).
+- ✅ FINISHED (f10480d, via 7.2) `server/bank.js:164`: `resolveAspsp` falls back to
+  `/norwegian/i` (a specific bank).
+- ✅ FINISHED (5268a8f, via 7.3) `server/seed.js`: real employer names (Telenor, Cognite),
+  Norwegian display-string categories (`'Mat'`) that bypass the canonical `CategoryKey`
+  system, a dead `laanetype` field, and an `INSERT OR REPLACE` that resets `rev` to 0 on an
+  already-migrated DB.
+- ✅ FINISHED (8c1264e) `PayslipImportModal.tsx:169,236`: literal "Visma" badge instead of
+  the provider-registry name.
+
+**5.5 ✅ FINISHED (a7c76e8, via 8.3) Hardcoded hex colours outside `chartColors.ts`.**
+(SVG contexts now use CHART.* via the 8.3 prop blocks; CSS contexts use theme vars. Left:
+ConfirmModal's bespoke `#9c4632` danger hover (no token) and the recurring
+`rgba(255,255,255,0.0x)` backgrounds, which need a new token rather than a swap.)
+SVG contexts that should use the `CHART.*` mirror: `SalaryPage` (axis `#5F6555`, grid
+`#262A20`, comp-chart gradient hexes), `PensionPage.tsx:147-166`,
+`ForecastPage.tsx:237-268`, `DebtSection.tsx`, `BudgetDistributionChart.tsx` (local copies
+of CHART values). CSS contexts where `var()` would already work: `FunBudget`,
+`GoalsSection.tsx:195`, `EditModal`, `NetWorthHistoryModal`, `CategoryBreakdown.tsx:29`,
+`DashboardPage.tsx:566` `#0E1310`, plus recurring `rgba(255,255,255,0.0x)` backgrounds.
+
+**5.6 🟢 Duplication worth one extraction each.**
+- Padded-lowercase haystack built identically in `categorize.ts`, `envelopes.ts`,
+  `labelRules.ts` (the word-boundary padding trick is documented in only one).
+- Twin-dedup logic maintained twice: `src/lib/bankDedup.ts:13-14` (TS) and
+  `server/bank.js:339-340` (`dropStaleBareTwins`, CJS); the regexes must stay
+  byte-equivalent. Also the `BARE` regex misclassifies a legacy ref that happens to start
+  with 8 hex chars + `-` as prefixed.
+- "Latest salary ≤ month" selection in both `src/lib/salary.ts:4-8` (`salaryAt`) and
+  `FinanceContext.tsx:238-243` (`calcActiveGrossAnnual`).
+- `SummaryTile`/`NumberRow`/`SliderRow` copy-pasted across `PensionPage.tsx:253-358`,
+  `EmployerCostPage.tsx:221-313`, ForecastPage, plus two more `SummaryTile` variants at
+  `SalaryPage.tsx:1316` and `LoanPage.tsx:945` (five total); `formatAxisInt` defined in
+  PensionPage, ForecastPage, and inline in AssetPage.
+- `BudgetPage.tsx:171` recomputes `totalFixedExpenses` locally; the context already exports
+  the identical memo (`FinanceContext.tsx:1160-1162`). Same for `incomeDiffPct`
+  (`BudgetPage.tsx:435` = `DashboardPage.tsx:89`).
+
+**5.7 🟢 Small hygiene items.** (four fixed in f43420f, marked below)
+- ✅ FINISHED (f43420f) `debt.ts:30-39` `amortize` reports the 600-month cap as
+  `months=600, feasible=false` while `planPayoff` uses `Infinity`. Mirrored, incl.
+  `perDebt[].payoffMonth`.
+- `validators.ts` `isPositiveNumber` accepts 0 (misleading name); `parseLocaleNumber`
+  rejects thousands-space while `coerceNumber` accepts it (two locale grammars).
+- `calculations.ts` `HomeownerStatus.equityPercent` is actually "% of original loan repaid";
+  rename before someone uses it as equity.
+- ✅ FINISHED (f43420f) `ForecastPage.tsx:141` leftover `void jobs;` removed.
+- `SettingsPage.tsx:98-100` currency inputs (`usdRateInput`/`customRateInput`) are seeded
+  once from context and never resync after a JSON import or demo toggle; `RangeRow` in the
+  same file shows the resync-effect pattern to copy.
+- `currentMonthKey()` inside `useMemo` with no time dep pins "current" across a month
+  boundary in a long-lived session (`PensionPage.tsx:38-41`, `ForecastPage.tsx:25-37`,
+  `EmployerCostPage.tsx:24-27`; cosmetic).
+- `deletedBankIds` grows unboundedly (`FinanceContext.tsx:751,823`); prune ids no longer
+  present in the stored blob.
+- ✅ FINISHED (f43420f) `resetAll` re-hardcodes `37.84/22/5/7/67`; now uses
+  `DEFAULT_ASSETS`/`DEFAULT_PENSION` (loan/homeowner/transition keep zero literals — their
+  DEFAULT_* constants hold non-zero example values, wrong for a wipe).
+- `server/bank.js` — ✅ FINISHED (f43420f) session/pending/config JSON writes are now
+  atomic (tmp+rename). Still open: `pickDate` (`bank.js:281`) falls back to `''`, storing
+  rows invisible to every month filter and undeletable via UI, and a feed omitting
+  `credit_debit_indicator` (`bank.js:293-306`) records refunds as positive expenses
+  (`amount: Math.abs(parsed)` + kind solely from `indicator === 'CRDT'`).
+
+---
+
+## 6. Test gaps
+
+- ✅ FINISHED (27b426e) `employerCost.ts`: zero tests for user-facing money maths
+  (AGA-on-combined-base, margin clamp). Locked in.
+- ✅ FINISHED (09cedf5) `norwegianTax.test.ts` has no golden-value test; every assertion is
+  structural, which is exactly why the wrong trygdeavgift rate (1.1) passes green. Add one
+  exact-total assertion per tax year against Skatteetaten's calculator.
+- ✅ FINISHED (27b426e) `calculations.ts`: `calcNetSaleProceeds`, `calcBridgeLoanCost`,
+  `calcHomeownerMortgageStatus` (incl. its fallback branch), `calcNetWorthProjectionByBucket`
+  are untested but rendered on Loan/Forecast.
+- 🟢 Anything extracted under 5.1 gets tests as part of the extraction.
+
+---
+
+## 7. Legacy & compat shims: inventory and retirement plan
+
+Every backward-compat shim in the codebase, with a verdict. "Keep forever" means the shim
+guards the import path, and old JSON backups in the wild never expire. All verified against
+source; `lang === 'nb'` was swept repo-wide and only the documented locale-selection
+carve-outs remain (Intl/date-fns locale, the Settings toggle, `formatMonths` in `debt.ts`),
+so the i18n migration needs no further work.
+
+| Shim | Serves | Verdict |
+|---|---|---|
+| `Assets.savings` scalar + `migrateSavingsAccounts` (`FinanceContext.tsx:141,699-718`) | pre-savingsAccounts blobs | needs migration (7.1) |
+| `sumSavings` scalar fallback (`equity.ts:16-21`) | old `balanceSnapshots` stored verbatim | keep until 7.1 migrates snapshots |
+| bare-vs-prefixed bank-id dedup, TS + CJS twins (`bankDedup.ts`, `bank.js:338-362`) | single-connection-era ids | keep; shrink after 2.3 converges the blob |
+| `reconcileBankTransactions` anti-clobber (`server/index.js:171-199`) | stale tab open during cron sync | keep (load-bearing), but see 2.3 |
+| `preserveUserFields` (`server/index.js:206-224`) | pre-accountLabels cached clients | extend to all user-authored fields or retire (2.6); half-covered is the worst state |
+| single-session → `connections[]` migration (`bank.js:204-231`) | pre-multi-bank `eb-session.json` | needs write-back migration (7.2) |
+| `resolveAspsp` `/norwegian/i` default (`bank.js:162-167`) | legacy connection with `aspsp: null` | retire via 7.2 |
+| plaintext-PEM read path (`bank.js:91`) | keys stored before at-rest encryption | ✅ FINISHED (75af71e) re-encrypts in place on first read |
+| `rev` ALTER migration (`server/index.js:97-99`) | pre-rev volumes (also fresh DBs) | keep, negligible |
+| no-`X-Data-Rev` → last-write-wins (`server/index.js:233-235`) | commented "legacy clients" | ✅ FINISHED (03fe6c8) beacon now carries `_rev`, comment fixed; the no-rev path is genuinely legacy-only |
+| `onboardingCompleted` absent → `true` (`FinanceContext.tsx:885-887`) | pre-tour blobs | keep forever |
+| `income` static scalar + fallbacks (`FinanceContext.tsx:740,1174-1204`) | non-salary-tracker users | keep (documented fallback); the 55000 default is a Norwegian magic number for fresh installs |
+| `FixedExpense.type?`, `DailyTransaction` optional fields | manual/old rows | keep forever (absence is first-class for manual rows) |
+| free-text category folding to `'other'` (`categoryStats.ts:74-95`) + hash-color fallback (`BudgetPage.tsx:100-110`) | pre-taxonomy labels | keep tolerance; fix the source (7.3) |
+| `useFinance()` merged shim (`FinanceContext.tsx:1973-1981`) | pre-slice-split consumers | keep (declared design) |
+| `GoalSource 'savings'` alongside `'savingsAccount'` (`FinanceContext.tsx:304`, `GoalsSection.tsx:15,74`) | old goals | keep (still offered as "total savings") |
+
+**7.1 ✅ FINISHED (d826219) Retire the `savings` scalar with a one-time load migration.**
+`migrateSavingsAccounts` already migrates scalar → a `'Sparekonto'` account but never clears
+the scalar, and `buildPayload` re-persists it forever; it also never touches
+`balanceSnapshots[*].assets` (stored verbatim, `applyPayload` `FinanceContext.tsx:867`),
+which is why `sumSavings` needs its fallback. Migration: in `applyPayload`, run each
+snapshot's assets through `migrateSavingsAccounts` and zero the live scalar; the client
+re-saves the whole blob after load, so the migration self-persists with no server machinery.
+Afterwards `savings?: number` remains only as an import-time input, and `DEFAULT_ASSETS`,
+`resetAll`, demo data drop it. Do 1.8 first or together (same field).
+
+**7.2 ✅ FINISHED (f10480d) Write back the migrated bank store and drop the hardcoded bank default.**
+`readStore` (`bank.js:204-231`) migrates the legacy single-session shape in memory only;
+disk keeps the old shape until an unrelated write, and the migrated connection has
+`aspsp: null`, which (a) makes `BankSyncCard.tsx:329` re-link fall through to the
+`/norwegian/i` default in `resolveAspsp`, and (b) makes `startLink`'s ASPSP match
+(`bank.js:404`) miss, so re-linking that bank via the picker mints a new prefixed
+connection, recreating the exact duplication the dedup shim cleans up. Fix: on startup, if
+`readStore` migrated, `writeStore` immediately and backfill `aspsp` (from its rows' `bank`
+field or by requiring one re-link); then delete the migration branch and the `/norwegian/i`
+default (also satisfies the no-hardcoded-bank rule, see 5.4).
+
+**7.3 ✅ FINISHED (5268a8f) `server/seed.js` mints fresh legacy-shaped data on every `make seed`.**
+The seed emits the oldest shape end-to-end: free-text categories (`'Mat'`, `'Kaffe'`) that
+the backfill effect deliberately preserves (`FinanceContext.tsx:1149` keeps any non-`other`
+label, so they render via the legacy hash-color path forever), rows without `kind`,
+`fixedExpenses` without `type`, scalar `savings` with no `savingsAccounts`, a `laanetype`
+field that isn't in `LoanData`, real employer names, and an `INSERT OR REPLACE (id,
+content)` that resets `rev` to 0 on an existing volume (forcing 409/adopt in open tabs).
+A friend's first impression exercises the oldest code path in the app. Fix: regenerate the
+seed to the current payload shape with canonical `CategoryKey`s and a rev-aware write.
+
+**Retirement order:** 1.8 → 7.3 → 2.3 (server-side twin convergence, then shrink
+`bankDedup.ts` to import-time only) → 7.2 → 7.1 → 2.6 (extend or retire
+`preserveUserFields`) → opportunistic PEM re-encrypt + comment fix on the no-rev path.
+
+---
+
+## 8. Duplication to consolidate (second pass)
+
+Ranked by payoff. Items already listed in 5.1/5.6 are not repeated here.
+
+**8.1 ✅ FINISHED (377b632) One modal scaffold for four hand-rolled modals; a11y drift already happened.**
+(`ui/ModalShell` owns portal/overlay/trap/dialog-semantics/header with icon, describedBy,
+initialFocus and footer slots; all four modals rewritten on it, NetWorthHistoryModal gaining
+the missing trap + role. The payslip lightbox keeps its own portal/trap.)
+`EditModal.tsx:51-73,157-170`, `ConfirmModal.tsx:22-39,40-55`,
+`PayslipImportModal.tsx:287-329`, `NetWorthHistoryModal.tsx:54-69,134-144` all hand-roll the
+identical stack: portal → overlay `fixed inset-0 bg-black/60 z-50 ...` with
+backdrop-click-close → panel with the same card classes → header row + X → byte-identical
+cancel/primary footer button class strings. The drift: the first three use `useFocusTrap` +
+`role="dialog"` + `aria-modal`; NetWorthHistoryModal has none of them (only a hand-rolled
+Escape listener at :34-38). Fix: `ui/ModalShell` (title, onClose, children, footer slots)
+wrapping portal/overlay/trap/header; bodies stay bespoke. ~70-90 lines saved and every
+future modal (onboarding is growing) inherits correct behavior.
+
+**8.2 ✅ FINISHED (966530a) DashboardPage reimplements the tested `categoryMoM`.**
+`DashboardPage.tsx:192-218` (`categoryDeltas`) inlines the same current-vs-previous-month
+per-category math as `categoryMoM` (`src/lib/categoryStats.ts:43-60`, unit-tested, already
+used by `CategoryBreakdown.tsx:23`), including the same pct formula. Side issue: it
+localizes the missing-category bucket at aggregation time (`t.dashboardPage.other` instead
+of the `'other'` key), making the bucket language-dependent data. Fix: call `categoryMoM`
+then filter/slice/map in the page; localize at render.
+
+**8.3 ✅ FINISHED (a7c76e8) Recharts axis/grid prop block copy-pasted ~26 times, with a token/hex fork.**
+(`AXIS_PROPS`/`AXIS_PROPS_Y`/`GRID_PROPS` exported and spread everywhere; page charts
+converged on the token design. Also fixed en-route: month labels in the five self-labelling
+chart components now follow the date-fns locale.)
+`tick={{ fontSize: 11, fill: ... }} axisLine={false} tickLine={false}` (plus the YAxis and
+`CartesianGrid strokeDasharray="3 3"` twins) appears in `CashflowChart.tsx:39-41`,
+`SavingsRateChart.tsx:37-39`, `CategoryTrendChart.tsx:38-40`,
+`NetWorthCompositionChart.tsx:52-54`, `LtvChart.tsx:39-41`, `DebtPayoffChart.tsx:68-70`
+(all using `CHART.*` tokens) and in `DebtSection.tsx:187-189`, `ForecastPage.tsx:237-239,
+266-268`, `SalaryPage.tsx:854-856,942-944,1038-1040,1078+`, AssetPage, PensionPage (same
+blocks with hardcoded `#262A20`/`#5F6555`, the old hex twins of the same tokens). Fix:
+export `AXIS_PROPS` / `AXIS_PROPS_Y` / `GRID_PROPS` from `src/lib/chartColors.ts` (already
+imported everywhere) and spread them; this also closes most of 5.5's SVG-context hex list.
+
+**8.4 🟡 FinanceContext CRUD triple × 7 entities.**
+`FinanceContext.tsx:1518-1582` (jobs, salaries, bonuses, overtime, hoursSnapshots, goals)
+plus savingsAccounts at :1442-1459 repeat the identical add/update/remove shape
+(`[...prev, {...entry, id: makeId(pfx)}]` / `map(x => x.id === id ? {...x, ...patch} : x)` /
+`filter(x => x.id !== id)`). Only variations: `addJob`/`addSalary` return the id (make the
+factory always return it) and `removeJob` cascades salary deletion (compose it). Fix: a
+~12-line `makeCrud<T>(setter, idPrefix)` in the same file; ~65 lines → ~20.
+
+**8.5 ✅ FINISHED (1ffc78f) CashflowChart and SavingsRateChart duplicate a 12-month money series builder.**
+(Extracted `monthlyCashflow()` + the `isSpend(tx)` spend predicate into
+`src/lib/monthlyCashflow.ts` with tests, and `lastNMonthKeys(anchor, n)` into
+`src/lib/date.ts`; the two charts, `CategoryTrendChart`, `MonthlyAccountSpend`,
+`DashboardPage`'s net-worth grid and `FinanceContext.incomeSeries` all use them now. Output
+is byte-identical to before.)
+`CashflowChart.tsx:23-34` vs `SavingsRateChart.tsx:21-32`: same
+`Array.from({length:12})`/`subMonths` grid, same `monthlyIncomes[key] ??
+Math.round(effectiveIncome)` fallback, same `tx.date.startsWith(key) && tx.kind !==
+'income'` spend filter; they differ only in transaction source (raw vs
+`nonTransferTransactions`, which is finding 1.5) and the final expression. Fix: one tested
+helper in `src/lib/` next to `monthlySpend.ts`; this puts the app's "what counts as spend"
+predicate (currently inlined 4+ times plus `envelopes.ts:124`) under test. Add
+`lastNMonthKeys(anchor, n)` to `src/lib/date.ts` while at it; the "last N month keys"
+expression has 5+ copies (`MonthlyAccountSpend.tsx:15`, `CategoryTrendChart.tsx:19`,
+`DashboardPage.tsx:117-118`, both charts above, variants in `InsightBanner.tsx:17` and
+`FinanceContext.tsx:1219`).
+
+**8.6 ✅ FINISHED (9c142c4) Ten hand-rolled progress bars with inconsistent clamping.**
+(Eleven sites by ship time — CategoryBreakdown and SmartRecommendations had grown bars too.
+`ui/ProgressBar` clamps to [0,100] and renders NaN/Infinity as 0; segmented bars left as-is.)
+`BudgetPage.tsx:82-84`, `CategoryBudgets.tsx:96-100`, `GoalsSection.tsx:200-206`,
+`FunBudget.tsx:73-78`, `LoanPage.tsx:527-531,543-547`, `DashboardPage.tsx:663-664,818-822`,
+`OnboardingTour.tsx:215-216`. Differences are height, track token, and clamping: some
+`Math.min(100, ...)`, some pre-clamped, some rely on the caller (the NaN/overflow-in-render
+class CLAUDE.md warns about). Fix: `ui/ProgressBar` (pct, color, height?, clamps
+internally). The segmented bars (`EquityCompositionBar`, `LiquidLockedBar`) are a different
+shape; leave them.
+
+**8.7 ✅ FINISHED (1d0a4bd) Signed-percent formatter inlined ~12 times.**
+`` `${v >= 0 ? '+' : ''}${v.toFixed(1)}%` `` exists as local `fmtPct`
+(`SalaryPage.tsx:1518`) and inline at `SalaryPage.tsx:762,769,776-777,990,993,1213`,
+`DashboardPage.tsx:331,421,446,496` (abs variant at :261). Fix: `formatSignedPct(v, digits
+= 1)` in a new `src/lib/format.ts`; makes null → em-dash handling consistent.
+
+**8.8 🟢 Editable label/value row triplicated.** *(Assessed 2026-07-08, recommend dropping:
+beyond the wrapper classes the rows share almost nothing — LoanRow carries its own
+highlight/calculated colour logic + notes, SavingsAccountRow uses real buttons for a11y —
+so a slot component would be a bigger abstraction than the duplication it removes.)*
+`AssetPage.tsx:598-621` (AssetRow), `:624-673` (SavingsAccountRow),
+`LoanPage.tsx:871-917` (LoanRow): same wrapper classes, same hover-reveal `Edit2` icon,
+same alignment spacer; they differ only in trailing extras (notes/reset, trash, icon).
+Fix: one `ui/EditableRow` with slots.
+
+**8.9 🟢 Server boilerplate in `server/index.js`.**
+Blob read (`getStmt.get('headroom')` + `JSON.parse`) repeated at :177-185, :206-214, and
+:388-390 (the last one, in `/api/bank/sync`, has an unguarded parse); extract `readBlob()`.
+Seven bank routes repeat the same try/catch-to-status wrapper (:317-414); a tiny handler
+wrapper removes it.
+
+**8.10 🟢 Structural (flagged, not a quick fix): a declarative payload-field registry.**
+`buildPayload` (`FinanceContext.tsx:832-852`), `applyPayload`'s ~35
+`if (data.x !== undefined) setX(...) else if (resetMissing) setX(DEFAULT)` lines
+(:854-914), the demo snapshot, and the SettingsPage export are four hand-synced copies of
+the same field list; CLAUDE.md documents the hazard. A registry
+(`{key, setter, default, group}[]`) would collapse `applyPayload` and make `buildPayload`
+derivable, eliminating the drift class behind 2.4/2.5/2.6 permanently. Architecture-level;
+needs its own task with throwaway-`DATA_DIR` round-trip tests, not a drive-by.
+
+Also noted: `BudgetDistributionChart.tsx:43-59` hand-rolls a tooltip card that the shared
+`ChartTooltip` could serve with a small "extra line" slot.
+
+---
+
+## 9. Verified correct (no action)
+
+Checked in depth and found sound: `calcMonthlyPayment` / `calcAmortizationSchedule` /
+`calcBorrowingCapacity` (match utlånsforskriften incl. the +3pp stress test); all 2025
+trinnskatt brackets and deductions except 1.1; `debt.ts` payoff engine (interest-first
+ordering, avalanche ≤ snowball invariant, revolving exclusion); `envelopes.ts` (no double
+counting, day-accurate spillover); `categoryStats.ts` (null MoM on zero prior);
+`transfers.ts` heuristics; `date.ts` month-key maths (local-time safe, year boundaries);
+`netWorth.ts` interpolation; payslip amount grammar (NBSP/thin-space); rounding done only at
+output edges (no accumulation); nominal `rate/12` used consistently.
+
+Persistence backbone: the CLAUDE.md "hand-maintained in several places" hazard is
+structurally fixed; `buildPayload()`/`applyPayload()` are single choke points, and a
+field-by-field matrix of all 44 payload fields found only the gaps listed in 2.4/2.5/2.6.
+Initial-load guard, debounce/abort/backoff, demo-mode never-persist, SQLite single-statement
+upsert, the rev/409 header path, SSB stale-cache handling, and `mapEBTransaction` malformed-
+row rejection all verified sound.
+
+Sanity checks on the pages: SalaryPage comp-chart stack sums exactly to its total label;
+month-string comparisons are consistently `YYYY-MM` lexicographic; no stale `useMemo` dep
+arrays found beyond the two cosmetic items in 5.7; no dead buttons found.
+
+---
+
+## Suggested order of attack
+
+1. Section 1 (wrong numbers), each item is small and independently shippable; 1.1/1.2
+   together with the golden-value tax test from section 6; 1.8 first of all (it loses
+   onboarding users' money and onboarding is the current project goal).
+2. Section 2 (data safety), 2.1 and 2.2 first.
+3. Section 7's retirement order (1.8 → 7.3 seed regen → 2.3 → 7.2 → 7.1 → 2.6); it
+   overlaps section 2 and stops new legacy-shaped data being minted.
+4. Section 3 whenever convenient (only matters with two open clients of the same
+   instance, e.g. laptop + phone PWA).
+5. Section 4 as a themed "consistency" pass (4.1 and 4.5 ride on the existing BACKLOG debt-
+   historization item).
+6. Sections 5, 6 and 8 as background cleanup, one theme per PR (i18n sweep, colour sweep
+   via 8.3, parse sweep, modal shell 8.1, lib extractions 8.2/8.5). 8.10 (payload-field
+   registry) is its own carefully-tested task.

--- a/src/components/MonthlyAccountSpend.tsx
+++ b/src/components/MonthlyAccountSpend.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
-import { format, subMonths } from 'date-fns';
+import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../context/FinanceContext';
+import { lastNMonthKeys } from '../lib/date';
 import { accountMonthlyTotals, monthlyColumnTotals } from '../lib/monthlySpend';
 import { accountToken } from '../lib/accountColor';
 
@@ -14,7 +15,7 @@ export function MonthlyAccountSpend() {
   const dateLocale = lang === 'nb' ? nb : enUS;
 
   const { months, rows, colTotals } = useMemo(() => {
-    const months = Array.from({ length: MONTHS }, (_, i) => format(subMonths(currentMonth, MONTHS - 1 - i), 'yyyy-MM'));
+    const months = lastNMonthKeys(currentMonth, MONTHS);
     const rows = accountMonthlyTotals(nonTransferTransactions, accountLabels, months);
     return { months, rows, colTotals: monthlyColumnTotals(rows, MONTHS) };
   }, [currentMonth, nonTransferTransactions, accountLabels]);

--- a/src/components/charts/CashflowChart.tsx
+++ b/src/components/charts/CashflowChart.tsx
@@ -2,11 +2,13 @@ import { useMemo } from 'react';
 import {
   ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
 } from 'recharts';
-import { format, subMonths } from 'date-fns';
+import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
+import { lastNMonthKeys } from '../../lib/date';
+import { monthlyCashflow } from '../../lib/monthlyCashflow';
 
 /**
  * Monthly cashflow for the last 12 months: money in (income) vs money out
@@ -25,16 +27,12 @@ export default function CashflowChart() {
   const dateLocale = lang === 'nb' ? nb : enUS;
 
   const data = useMemo(() => {
-    return Array.from({ length: 12 }, (_, i) => {
-      const d = subMonths(currentMonth, 11 - i);
-      const key = format(d, 'yyyy-MM');
-      const income = monthlyIncomes[key] ?? Math.round(effectiveIncome);
-      const variable = dailyTransactions
-        .filter(tx => tx.date.startsWith(key) && tx.kind !== 'income')
-        .reduce((s, tx) => s + tx.amount, 0);
-      const expenses = totalFixedExpenses + variable;
-      return { label: format(d, 'MMM', { locale: dateLocale }), income, expenses, net: income - expenses };
-    });
+    const months = lastNMonthKeys(currentMonth, 12);
+    return monthlyCashflow(months, dailyTransactions, monthlyIncomes, Math.round(effectiveIncome), totalFixedExpenses)
+      .map(({ month, income, expenses, net }) => ({
+        label: format(new Date(`${month}-01T00:00:00`), 'MMM', { locale: dateLocale }),
+        income, expenses, net,
+      }));
   }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions, dateLocale]);
 
   return (

--- a/src/components/charts/CategoryTrendChart.tsx
+++ b/src/components/charts/CategoryTrendChart.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LabelList } from 'recharts';
-import { format, subMonths } from 'date-fns';
+import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
+import { lastNMonthKeys } from '../../lib/date';
 import { CATEGORIES } from '../../lib/categories';
 import { monthlyCategoryTotals } from '../../lib/categoryStats';
 
@@ -18,7 +19,7 @@ export default function CategoryTrendChart() {
   const dateLocale = lang === 'nb' ? nb : enUS;
 
   const { data, series } = useMemo(() => {
-    const months = Array.from({ length: MONTHS }, (_, i) => format(subMonths(currentMonth, MONTHS - 1 - i), 'yyyy-MM'));
+    const months = lastNMonthKeys(currentMonth, MONTHS);
     const rows = monthlyCategoryTotals(dailyTransactions, months);
     const data = rows.map((r) => ({ ...r, label: format(new Date(`${r.month}-01T00:00:00`), 'MMM', { locale: dateLocale }) }));
     // Keep only categories that appear at least once across the window.

--- a/src/components/charts/SavingsRateChart.tsx
+++ b/src/components/charts/SavingsRateChart.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
-import { format, subMonths } from 'date-fns';
+import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance } from '../../context/FinanceContext';
 import ChartTooltip from '../ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../../lib/chartColors';
+import { lastNMonthKeys } from '../../lib/date';
+import { monthlyCashflow } from '../../lib/monthlyCashflow';
 
 /**
  * Monthly savings capacity as a rate: the share of income left after fixed
@@ -21,16 +23,12 @@ export default function SavingsRateChart() {
   const dateLocale = lang === 'nb' ? nb : enUS;
 
   const data = useMemo(() => {
-    return Array.from({ length: 12 }, (_, i) => {
-      const d = subMonths(currentMonth, 11 - i);
-      const key = format(d, 'yyyy-MM');
-      const income = monthlyIncomes[key] ?? Math.round(effectiveIncome);
-      const variable = dailyTransactions
-        .filter(tx => tx.date.startsWith(key) && tx.kind !== 'income')
-        .reduce((s, tx) => s + tx.amount, 0);
-      const rate = income > 0 ? ((income - totalFixedExpenses - variable) / income) * 100 : 0;
-      return { label: format(d, 'MMM', { locale: dateLocale }), rate: Math.round(rate * 10) / 10 };
-    });
+    const months = lastNMonthKeys(currentMonth, 12);
+    return monthlyCashflow(months, dailyTransactions, monthlyIncomes, Math.round(effectiveIncome), totalFixedExpenses)
+      .map(({ month, rate }) => ({
+        label: format(new Date(`${month}-01T00:00:00`), 'MMM', { locale: dateLocale }),
+        rate,
+      }));
   }, [currentMonth, monthlyIncomes, effectiveIncome, totalFixedExpenses, dailyTransactions, dateLocale]);
 
   return (

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -710,6 +710,25 @@ export interface DailyDataEntry {
 const makeId = (prefix: string) =>
   `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
 
+// The add/update/remove triple shared by every id-keyed array entity (jobs,
+// salaries, bonuses, overtime, hours snapshots, goals). `add` mints an id and
+// returns it (callers that don't need it, e.g. bonuses, ignore the return).
+// Built once from a stable useState setter, so the actions stay referentially
+// stable (memoize the result with empty deps).
+type ArraySetter<T> = (updater: (prev: T[]) => T[]) => void;
+function makeCrud<T extends { id: string }>(setter: ArraySetter<T>, prefix: string) {
+  return {
+    add: (entry: Omit<T, 'id'>): string => {
+      const id = makeId(prefix);
+      setter(prev => [...prev, { ...entry, id } as T]);
+      return id;
+    },
+    update: (id: string, patch: Partial<Omit<T, 'id'>>): void =>
+      setter(prev => prev.map(x => (x.id === id ? { ...x, ...patch } : x))),
+    remove: (id: string): void => setter(prev => prev.filter(x => x.id !== id)),
+  };
+}
+
 // Normalise a loaded/imported assets blob into a savings-accounts array. If the
 // array is present it's cleaned (valid id/name/number balance); when it's absent
 // *or empty*, a nonzero legacy `savings` scalar is migrated into one account
@@ -1523,24 +1542,20 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  // savingsAccounts is nested in `assets`; adapt setAssets to the array-setter
+  // shape so it shares the same CRUD triple as the top-level entities.
+  const savingsCrud = useMemo(
+    () => makeCrud<SavingsAccount>(
+      updater => setAssets(prev => ({ ...prev, savingsAccounts: updater(prev.savingsAccounts ?? []) })),
+      'sav',
+    ),
+    [],
+  );
   const addSavingsAccount = useCallback((name: string, balance: number) => {
-    setAssets(prev => ({
-      ...prev,
-      savingsAccounts: [...(prev.savingsAccounts ?? []), { id: makeId('sav'), name, balance }],
-    }));
-  }, []);
-  const updateSavingsAccount = useCallback((id: string, patch: Partial<Omit<SavingsAccount, 'id'>>) => {
-    setAssets(prev => ({
-      ...prev,
-      savingsAccounts: (prev.savingsAccounts ?? []).map(s => s.id === id ? { ...s, ...patch } : s),
-    }));
-  }, []);
-  const removeSavingsAccount = useCallback((id: string) => {
-    setAssets(prev => ({
-      ...prev,
-      savingsAccounts: (prev.savingsAccounts ?? []).filter(s => s.id !== id),
-    }));
-  }, []);
+    savingsCrud.add({ name, balance });
+  }, [savingsCrud]);
+  const updateSavingsAccount = savingsCrud.update;
+  const removeSavingsAccount = savingsCrud.remove;
 
   const updateLoan = useCallback((key: keyof LoanData, value: number | string) => {
     setLoan(prev => ({ ...prev, [key]: value }));
@@ -1599,71 +1614,41 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     }
   }, [homeowner]);
 
-  const addJob = useCallback((job: Omit<JobEntry, 'id'>): string => {
-    const id = makeId('job');
-    setJobs(prev => [...prev, { ...job, id }]);
-    return id;
-  }, []);
-  const updateJob = useCallback((id: string, patch: Partial<Omit<JobEntry, 'id'>>) => {
-    setJobs(prev => prev.map(j => j.id === id ? { ...j, ...patch } : j));
-  }, []);
+  // useState setters are stable, so each CRUD bundle is built once.
+  const jobsCrud = useMemo(() => makeCrud<JobEntry>(setJobs, 'job'), []);
+  const salariesCrud = useMemo(() => makeCrud<SalaryEntry>(setSalaries, 'sal'), []);
+  const bonusesCrud = useMemo(() => makeCrud<BonusEntry>(setBonuses, 'bon'), []);
+  const overtimeCrud = useMemo(() => makeCrud<OvertimeEntry>(setOvertime, 'ot'), []);
+  const hoursCrud = useMemo(() => makeCrud<HoursSnapshot>(setHoursSnapshots, 'hrs'), []);
+  const goalsCrud = useMemo(() => makeCrud<Goal>(setGoals, 'goal'), []);
+
+  const addJob = jobsCrud.add;
+  const updateJob = jobsCrud.update;
   const removeJob = useCallback((id: string) => {
-    setJobs(prev => prev.filter(j => j.id !== id));
+    jobsCrud.remove(id);
     // Cascade: remove orphaned salaries
     setSalaries(prev => prev.filter(s => s.jobId !== id));
-  }, []);
+  }, [jobsCrud]);
 
-  const addSalary = useCallback((entry: Omit<SalaryEntry, 'id'>): string => {
-    const id = makeId('sal');
-    setSalaries(prev => [...prev, { ...entry, id }]);
-    return id;
-  }, []);
-  const updateSalary = useCallback((id: string, patch: Partial<Omit<SalaryEntry, 'id'>>) => {
-    setSalaries(prev => prev.map(s => s.id === id ? { ...s, ...patch } : s));
-  }, []);
-  const removeSalary = useCallback((id: string) => {
-    setSalaries(prev => prev.filter(s => s.id !== id));
-  }, []);
+  const addSalary = salariesCrud.add;
+  const updateSalary = salariesCrud.update;
+  const removeSalary = salariesCrud.remove;
 
-  const addBonus = useCallback((entry: Omit<BonusEntry, 'id'>) => {
-    setBonuses(prev => [...prev, { ...entry, id: makeId('bon') }]);
-  }, []);
-  const updateBonus = useCallback((id: string, patch: Partial<Omit<BonusEntry, 'id'>>) => {
-    setBonuses(prev => prev.map(b => b.id === id ? { ...b, ...patch } : b));
-  }, []);
-  const removeBonus = useCallback((id: string) => {
-    setBonuses(prev => prev.filter(b => b.id !== id));
-  }, []);
+  const addBonus = bonusesCrud.add;
+  const updateBonus = bonusesCrud.update;
+  const removeBonus = bonusesCrud.remove;
 
-  const addOvertime = useCallback((entry: Omit<OvertimeEntry, 'id'>) => {
-    setOvertime(prev => [...prev, { ...entry, id: makeId('ot') }]);
-  }, []);
-  const updateOvertime = useCallback((id: string, patch: Partial<Omit<OvertimeEntry, 'id'>>) => {
-    setOvertime(prev => prev.map(o => o.id === id ? { ...o, ...patch } : o));
-  }, []);
-  const removeOvertime = useCallback((id: string) => {
-    setOvertime(prev => prev.filter(o => o.id !== id));
-  }, []);
+  const addOvertime = overtimeCrud.add;
+  const updateOvertime = overtimeCrud.update;
+  const removeOvertime = overtimeCrud.remove;
 
-  const addHoursSnapshot = useCallback((entry: Omit<HoursSnapshot, 'id'>) => {
-    setHoursSnapshots(prev => [...prev, { ...entry, id: makeId('hrs') }]);
-  }, []);
-  const updateHoursSnapshot = useCallback((id: string, patch: Partial<Omit<HoursSnapshot, 'id'>>) => {
-    setHoursSnapshots(prev => prev.map(h => h.id === id ? { ...h, ...patch } : h));
-  }, []);
-  const removeHoursSnapshot = useCallback((id: string) => {
-    setHoursSnapshots(prev => prev.filter(h => h.id !== id));
-  }, []);
+  const addHoursSnapshot = hoursCrud.add;
+  const updateHoursSnapshot = hoursCrud.update;
+  const removeHoursSnapshot = hoursCrud.remove;
 
-  const addGoal = useCallback((g: Omit<Goal, 'id'>) => {
-    setGoals(prev => [...prev, { ...g, id: makeId('goal') }]);
-  }, []);
-  const updateGoal = useCallback((id: string, patch: Partial<Omit<Goal, 'id'>>) => {
-    setGoals(prev => prev.map(g => g.id === id ? { ...g, ...patch } : g));
-  }, []);
-  const removeGoal = useCallback((id: string) => {
-    setGoals(prev => prev.filter(g => g.id !== id));
-  }, []);
+  const addGoal = goalsCrud.add;
+  const updateGoal = goalsCrud.update;
+  const removeGoal = goalsCrud.remove;
 
   // Set (or clear, with null / ≤0) a category's monthly budget cap.
   const setCategoryBudget = useCallback((category: CategoryKey, amount: number | null) => {

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -22,6 +22,7 @@ import type { LabelRule } from '../lib/labelRules';
 import type { CategoryKey } from '../lib/categories';
 import { reconcile, runningEnvelopeBalance, discretionarySpendForMonth, type Reconciliation } from '../lib/envelopes';
 import { findInternalTransferIds } from '../lib/transfers';
+import { lastNMonthKeys } from '../lib/date';
 import { accountGroupLabel, accountGroupKey } from '../lib/account';
 import { sumDebtByType } from '../lib/debt';
 import { dedupeBankTransactions } from '../lib/bankDedup';
@@ -1271,14 +1272,13 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   // its manual override if set, otherwise the income derived for THAT month. This
   // reflects real income history — averaging only the overrides map (any months
   // ever set, including the future) badly skews the mean and volatility.
-  const incomeSeries = useMemo(() => {
-    const series: { month: string; value: number }[] = [];
-    for (let i = 11; i >= 0; i--) {
-      const mKey = format(subMonths(currentMonth, i), 'yyyy-MM');
-      series.push({ month: mKey, value: monthlyIncomes[mKey] ?? derivedNetMonthlyFor(mKey) });
-    }
-    return series;
-  }, [monthlyIncomes, currentMonth, derivedNetMonthlyFor]);
+  const incomeSeries = useMemo(
+    () => lastNMonthKeys(currentMonth, 12).map((mKey) => ({
+      month: mKey,
+      value: monthlyIncomes[mKey] ?? derivedNetMonthlyFor(mKey),
+    })),
+    [monthlyIncomes, currentMonth, derivedNetMonthlyFor],
+  );
 
   const averageIncome = useMemo(
     () => Math.round(incomeSeries.reduce((s, p) => s + p.value, 0) / incomeSeries.length),

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from './date';
+import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf, lastNMonthKeys } from './date';
 
 describe('monthKeyFromDate', () => {
   it('formats a date as a local yyyy-MM key with zero-padding', () => {
@@ -40,6 +40,23 @@ describe('monthsBetween', () => {
 
   it('returns empty when from is after to', () => {
     expect(monthsBetween('2026-07', '2026-06')).toEqual([]);
+  });
+});
+
+describe('lastNMonthKeys', () => {
+  it('returns n keys ending at the anchor month, oldest first', () => {
+    expect(lastNMonthKeys(new Date(2026, 6, 8), 12)).toEqual([
+      '2025-08', '2025-09', '2025-10', '2025-11', '2025-12',
+      '2026-01', '2026-02', '2026-03', '2026-04', '2026-05', '2026-06', '2026-07',
+    ]);
+  });
+
+  it('spans year boundaries and uses local time (not UTC slicing)', () => {
+    expect(lastNMonthKeys(new Date(2026, 0, 1), 3)).toEqual(['2025-11', '2025-12', '2026-01']);
+  });
+
+  it('returns a single key for n = 1', () => {
+    expect(lastNMonthKeys(new Date(2026, 6, 1), 1)).toEqual(['2026-07']);
   });
 });
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -41,3 +41,14 @@ export function monthsBetween(from: string, to: string): string[] {
 export function yearOf(monthOrDate: string): number {
   return parseInt(monthOrDate.slice(0, 4), 10);
 }
+
+/**
+ * The `n` 'yyyy-MM' keys ending at `anchor`'s month, oldest first.
+ * `lastNMonthKeys(new Date(2026, 6, 1), 12)` → ['2025-08', …, '2026-07'].
+ * Local-time safe (unlike ISO slicing); replaces the repeated
+ * `Array.from({length:n}, (_, i) => format(subMonths(anchor, n-1-i), 'yyyy-MM'))`.
+ */
+export function lastNMonthKeys(anchor: Date, n: number): string[] {
+  const end = monthKeyFromDate(anchor);
+  return Array.from({ length: n }, (_, i) => addMonthsKey(end, i - (n - 1)));
+}

--- a/src/lib/monthlyCashflow.test.ts
+++ b/src/lib/monthlyCashflow.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isSpend, monthlyCashflow } from './monthlyCashflow';
+import type { DailyTransaction } from '../context/FinanceContext';
+
+const tx = (over: Partial<DailyTransaction>): DailyTransaction => ({
+  id: Math.random().toString(36).slice(2),
+  date: '2026-06-15',
+  description: 'x',
+  amount: 0,
+  ...over,
+});
+
+describe('isSpend', () => {
+  it('counts expenses and treats a missing kind as spend', () => {
+    expect(isSpend(tx({ kind: 'expense' }))).toBe(true);
+    expect(isSpend(tx({}))).toBe(true);
+  });
+
+  it('excludes income', () => {
+    expect(isSpend(tx({ kind: 'income' }))).toBe(false);
+  });
+});
+
+describe('monthlyCashflow', () => {
+  const months = ['2026-05', '2026-06'];
+  const txs = [
+    tx({ date: '2026-06-03', amount: 200, kind: 'expense' }),
+    tx({ date: '2026-06-20', amount: 300 }), // no kind → spend
+    tx({ date: '2026-06-10', amount: 5000, kind: 'income' }), // ignored
+    tx({ date: '2026-05-01', amount: 100, kind: 'expense' }),
+    tx({ date: '2026-04-01', amount: 999, kind: 'expense' }), // outside window
+  ];
+
+  it('sums only spend into variable, per month', () => {
+    const rows = monthlyCashflow(months, txs, {}, 40000, 10000);
+    expect(rows.map(r => r.variable)).toEqual([100, 500]);
+  });
+
+  it('uses the manual income override when set, else the fallback', () => {
+    const rows = monthlyCashflow(months, txs, { '2026-06': 50000 }, 40000, 10000);
+    expect(rows[0].income).toBe(40000); // May → fallback
+    expect(rows[1].income).toBe(50000); // June → override
+  });
+
+  it('adds fixed expenses to variable and computes net', () => {
+    const rows = monthlyCashflow(months, txs, {}, 40000, 10000);
+    // June: expenses = 10000 + 500 = 10500; net = 40000 - 10500
+    expect(rows[1].expenses).toBe(10500);
+    expect(rows[1].net).toBe(29500);
+  });
+
+  it('computes the savings rate as a rounded percent of income', () => {
+    const rows = monthlyCashflow(['2026-06'], [tx({ date: '2026-06-01', amount: 500, kind: 'expense' })], {}, 40000, 10000);
+    // (40000 - 10500) / 40000 * 100 = 73.75
+    expect(rows[0].rate).toBe(73.8);
+  });
+
+  it('reports a zero rate when income is non-positive (no divide-by-zero)', () => {
+    const rows = monthlyCashflow(['2026-06'], [], {}, 0, 5000);
+    expect(rows[0].rate).toBe(0);
+    expect(rows[0].net).toBe(-5000);
+  });
+});

--- a/src/lib/monthlyCashflow.ts
+++ b/src/lib/monthlyCashflow.ts
@@ -1,0 +1,47 @@
+// The 12-month "money in vs money out" series behind CashflowChart and
+// SavingsRateChart. Pure + unit-tested. Income for a month is its manual
+// override when set, else a flat fallback (the current effective income) as an
+// estimate; fixed expenses aren't snapshotted, so the same current total is
+// applied to every month and past months are approximate.
+import type { DailyTransaction } from '../context/FinanceContext';
+
+/**
+ * Whether a transaction counts as spend (money out). Income rows are excluded;
+ * a missing `kind` is treated as an expense (legacy rows). This is the app's
+ * one "what counts as spend" predicate — keep other spend filters in sync.
+ */
+export function isSpend(tx: DailyTransaction): boolean {
+  return tx.kind !== 'income';
+}
+
+export interface MonthlyCashflowRow {
+  month: string; // 'yyyy-MM'
+  income: number;
+  variable: number; // logged expense transactions in the month
+  expenses: number; // fixedExpenses + variable
+  net: number; // income - expenses
+  /** Savings rate as a percent of income; 0 when income ≤ 0. */
+  rate: number;
+}
+
+export function monthlyCashflow(
+  months: string[],
+  txs: DailyTransaction[],
+  monthlyIncomes: Record<string, number>,
+  fallbackIncome: number,
+  totalFixedExpenses: number,
+): MonthlyCashflowRow[] {
+  const spendByMonth = new Map<string, number>();
+  for (const tx of txs) {
+    if (!isSpend(tx)) continue;
+    const key = tx.date.slice(0, 7);
+    spendByMonth.set(key, (spendByMonth.get(key) ?? 0) + tx.amount);
+  }
+  return months.map((month) => {
+    const income = monthlyIncomes[month] ?? fallbackIncome;
+    const variable = spendByMonth.get(month) ?? 0;
+    const expenses = totalFixedExpenses + variable;
+    const rate = income > 0 ? Math.round(((income - expenses) / income) * 1000) / 10 : 0;
+    return { month, income, variable, expenses, net: income - expenses, rate };
+  });
+}

--- a/src/lib/pension.test.ts
+++ b/src/lib/pension.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { pensionFutureValue, projectPensionWealth } from './pension';
+
+describe('pensionFutureValue', () => {
+  it('returns the starting balance for zero or negative years', () => {
+    expect(pensionFutureValue(100000, 5000, 5, 0)).toBe(100000);
+    expect(pensionFutureValue(100000, 5000, 5, -3)).toBe(100000);
+  });
+
+  it('accumulates linearly at a ~0% rate', () => {
+    expect(pensionFutureValue(100000, 5000, 0, 4)).toBe(120000);
+  });
+
+  it('matches the iterative recurrence next = prev*(1+r) + contribution', () => {
+    const start = 200000, contrib = 30000, ratePct = 6, years = 10;
+    let bal = start;
+    for (let i = 0; i < years; i++) bal = bal * (1 + ratePct / 100) + contrib;
+    expect(pensionFutureValue(start, contrib, ratePct, years)).toBeCloseTo(bal, 6);
+  });
+});
+
+describe('projectPensionWealth', () => {
+  const params = {
+    otpBalance: 300000, ipsBalance: 50000,
+    otpAnnualContribution: 40000, ipsAnnualContribution: 15000,
+    otpGrowthRate: 5, ipsGrowthRate: 4,
+    yearsToRetire: 20, startYear: 2026,
+  };
+
+  it('starts at year 0 with today\'s balances and spans to retirement inclusive', () => {
+    const series = projectPensionWealth(params);
+    expect(series).toHaveLength(21);
+    expect(series[0]).toEqual({ year: 2026, otp: 300000, ips: 50000, total: 350000 });
+    expect(series[series.length - 1].year).toBe(2046);
+  });
+
+  it('has total equal to the rounded sum of the raw otp and ips', () => {
+    const series = projectPensionWealth(params);
+    for (const p of series) {
+      // total is rounded from the unrounded sum, so it is within 1 of otp+ips
+      expect(Math.abs(p.total - (p.otp + p.ips))).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('final balances match pensionFutureValue', () => {
+    const series = projectPensionWealth(params);
+    const last = series[series.length - 1];
+    expect(last.otp).toBe(Math.round(pensionFutureValue(params.otpBalance, params.otpAnnualContribution, params.otpGrowthRate, 20)));
+    expect(last.ips).toBe(Math.round(pensionFutureValue(params.ipsBalance, params.ipsAnnualContribution, params.ipsGrowthRate, 20)));
+  });
+
+  it('returns a single year when already at retirement', () => {
+    const series = projectPensionWealth({ ...params, yearsToRetire: 0 });
+    expect(series).toHaveLength(1);
+    expect(series[0].total).toBe(350000);
+  });
+});

--- a/src/lib/pension.ts
+++ b/src/lib/pension.ts
@@ -1,0 +1,49 @@
+// Pension wealth projection, shared by PensionPage (year-by-year series) and
+// ForecastPage (final value only). Pure + unit-tested. Contributions land at the
+// END of each year and then grow; the closed form matches the iterative
+// year-by-year recurrence `next = prev * (1 + r) + contribution`.
+
+/**
+ * Balance after `years` full years of annual growth at `ratePct` percent with a
+ * fixed end-of-year contribution. `years <= 0` returns `start`; a ~0% rate
+ * degrades to linear accumulation (no annuity denominator).
+ */
+export function pensionFutureValue(start: number, contribution: number, ratePct: number, years: number): number {
+  const r = ratePct / 100;
+  if (years <= 0) return start;
+  if (Math.abs(r) < 1e-9) return start + contribution * years;
+  return start * Math.pow(1 + r, years) + contribution * (Math.pow(1 + r, years) - 1) / r;
+}
+
+export interface PensionProjectionParams {
+  otpBalance: number;
+  ipsBalance: number;
+  otpAnnualContribution: number;
+  ipsAnnualContribution: number;
+  otpGrowthRate: number; // percent
+  ipsGrowthRate: number; // percent
+  yearsToRetire: number;
+  startYear: number;
+}
+
+export interface PensionYear {
+  year: number;
+  otp: number;
+  ips: number;
+  total: number;
+}
+
+/**
+ * Year-by-year OTP + IPS balances from now (year 0 = today's balances) through
+ * retirement, inclusive. Rounded at the output edge; `total` is rounded from the
+ * unrounded sum so it always equals what the chart's stacked bars display.
+ */
+export function projectPensionWealth(p: PensionProjectionParams): PensionYear[] {
+  const out: PensionYear[] = [];
+  for (let y = 0; y <= p.yearsToRetire; y++) {
+    const otp = pensionFutureValue(p.otpBalance, p.otpAnnualContribution, p.otpGrowthRate, y);
+    const ips = pensionFutureValue(p.ipsBalance, p.ipsAnnualContribution, p.ipsGrowthRate, y);
+    out.push({ year: p.startYear + y, otp: Math.round(otp), ips: Math.round(ips), total: Math.round(otp + ips) });
+  }
+  return out;
+}

--- a/src/lib/salary.test.ts
+++ b/src/lib/salary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { salaryAt, hoursAt } from './salary';
+import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH } from './salary';
 import type { SalaryEntry, JobEntry, HoursSnapshot } from '../context/FinanceContext';
 
 const sal = (id: string, effectiveDate: string, grossAnnual: number, jobId = 'j1'): SalaryEntry => ({
@@ -8,8 +8,24 @@ const sal = (id: string, effectiveDate: string, grossAnnual: number, jobId = 'j1
 const job = (id: string, contractedHoursPerWeek: number): JobEntry => ({
   id, startDate: '2020-01', endDate: null, employer: 'Acme', role: 'Dev', contractedHoursPerWeek,
 });
-const snap = (id: string, periodMonth: string, actualHoursPerWeek: number): HoursSnapshot => ({
-  id, periodMonth, actualHoursPerWeek,
+const snap = (id: string, periodMonth: string, actualHoursPerWeek: number, jobId?: string): HoursSnapshot => ({
+  id, periodMonth, actualHoursPerWeek, jobId,
+});
+
+describe('nominalHourlyRate', () => {
+  it('divides monthly pay (base + on-call) by monthly hours', () => {
+    // 37.5h/week × 4.345 weeks ≈ 162.94h/month
+    expect(nominalHourlyRate(60000, 0, 37.5)).toBeCloseTo(60000 / (WEEKS_PER_MONTH * 37.5), 6);
+  });
+
+  it('counts on-call pay toward the rate', () => {
+    expect(nominalHourlyRate(60000, 6000, 37.5)).toBeCloseTo(66000 / (WEEKS_PER_MONTH * 37.5), 6);
+  });
+
+  it('returns 0 for non-positive hours (no divide-by-zero)', () => {
+    expect(nominalHourlyRate(60000, 0, 0)).toBe(0);
+    expect(nominalHourlyRate(60000, 0, -5)).toBe(0);
+  });
 });
 
 describe('salaryAt', () => {
@@ -48,5 +64,22 @@ describe('hoursAt', () => {
   it('falls back to 37.5 when neither snapshot nor job resolves', () => {
     expect(hoursAt('2024-12', snaps, jobs, null)).toBe(37.5);
     expect(hoursAt('2024-12', snaps, [], sal('a', '2024-01', 600000, 'missing'))).toBe(37.5);
+  });
+
+  it('ignores a snapshot assigned to a different job, using the active job contracted hours', () => {
+    const twoJobs = [job('j1', 37.5), job('j2', 20)];
+    // A 40h snapshot belongs to the ended job j1; the active salary is for j2.
+    const jobSnaps = [snap('s1', '2025-01', 40, 'j1')];
+    expect(hoursAt('2025-06', jobSnaps, twoJobs, sal('b', '2025-05', 500000, 'j2'))).toBe(20);
+  });
+
+  it('applies a snapshot assigned to the active job', () => {
+    const jobSnaps = [snap('s1', '2025-01', 40, 'j1')];
+    expect(hoursAt('2025-06', jobSnaps, jobs, sal('b', '2025-05', 500000, 'j1'))).toBe(40);
+  });
+
+  it('applies unassigned snapshots to whichever job is active', () => {
+    const twoJobs = [job('j1', 37.5), job('j2', 20)];
+    expect(hoursAt('2025-09', snaps, twoJobs, sal('b', '2025-05', 500000, 'j2'))).toBe(32);
   });
 });

--- a/src/lib/salary.ts
+++ b/src/lib/salary.ts
@@ -1,5 +1,18 @@
 import type { SalaryEntry, JobEntry, HoursSnapshot } from '../context/FinanceContext';
 
+/** Average weeks in a month (52 / 12), for converting weekly hours to monthly. */
+export const WEEKS_PER_MONTH = 4.345;
+
+/**
+ * Nominal hourly rate: a month's total pay (base + on-call) over the hours
+ * worked that month. On-call is regular pay for hours on rotation, so it counts.
+ * Returns 0 when hours are non-positive (avoids divide-by-zero).
+ */
+export function nominalHourlyRate(monthlyGross: number, onCallMonthly: number, hoursPerWeek: number): number {
+  if (hoursPerWeek <= 0) return 0;
+  return (monthlyGross + onCallMonthly) / (WEEKS_PER_MONTH * hoursPerWeek);
+}
+
 /** Most recent salary in effect at the given month (inclusive), or null if none. */
 export function salaryAt(month: string, salaries: SalaryEntry[]): SalaryEntry | null {
   const eligible = salaries.filter(s => s.effectiveDate <= month);
@@ -10,6 +23,11 @@ export function salaryAt(month: string, salaries: SalaryEntry[]): SalaryEntry | 
 /**
  * Most recent hours snapshot at the given month; falls back to the contracted
  * hours of the active salary's job, then to a 37.5h default.
+ *
+ * A snapshot assigned to a specific job (`jobId`) only applies while that job is
+ * the active one — otherwise an old job's part-time snapshot would leak into a
+ * later, unrelated job's hourly maths. Unassigned snapshots (`jobId` undefined)
+ * are global and apply to whichever job is active.
  */
 export function hoursAt(
   month: string,
@@ -17,8 +35,9 @@ export function hoursAt(
   jobs: JobEntry[],
   salary: SalaryEntry | null,
 ): number {
+  const jobId = salary?.jobId;
   const snap = hoursSnapshots
-    .filter(h => h.periodMonth <= month)
+    .filter(h => h.periodMonth <= month && (h.jobId == null || h.jobId === jobId))
     .reduce<HoursSnapshot | null>((a, b) => (a && a.periodMonth > b.periodMonth ? a : b), null);
   if (snap) return snap.actualHoursPerWeek;
   if (salary) {

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -39,6 +39,11 @@ import { isCategoryKey } from '../lib/categories';
 const CashflowChart = lazy(() => import('../components/charts/CashflowChart'));
 const EmergencyFundGauge = lazy(() => import('../components/charts/EmergencyFundGauge'));
 
+// Assumed growth applied to each projected (future) month's income bar (~2%/month).
+const PROJECTED_INCOME_GROWTH = 1.02;
+// Target reference line on the income sparkline, drawn at 85% of the tallest bar.
+const INCOME_TARGET_SHARE = 0.85;
+
 const DashboardPage: React.FC = () => {
   const {
     t,
@@ -210,7 +215,7 @@ const DashboardPage: React.FC = () => {
       for (let i = 1; i <= 2; i++) {
         const d = parse(last.month, 'yyyy-MM', new Date());
         d.setMonth(d.getMonth() + i);
-        months.push({ key: `proj-${i}`, label: fmtDate(d, 'MMM', { locale: dateLocale }), value: Math.round(baseVal * 1.02 ** i), projected: true });
+        months.push({ key: `proj-${i}`, label: fmtDate(d, 'MMM', { locale: dateLocale }), value: Math.round(baseVal * PROJECTED_INCOME_GROWTH ** i), projected: true });
       }
     }
     return months;
@@ -1114,14 +1119,14 @@ function MonthlyInvestmentBars({ bars }: { bars: { key: string; label: string; v
       display.push({
         key: `proj-extra-${i}`,
         label: '',
-        value: Math.round(baseVal * Math.pow(1.02, i + (bars.length - realBars.length))),
+        value: Math.round(baseVal * Math.pow(PROJECTED_INCOME_GROWTH, i + (bars.length - realBars.length))),
         projected: true,
       });
     }
   }
 
   const max = Math.max(...display.map(b => b.value)) || 1;
-  const target = max * 0.85;
+  const target = max * INCOME_TARGET_SHARE;
   const todayIdx = realBars.length - 1;
 
   return (

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -29,6 +29,7 @@ import {
 import ChartTooltip from '../components/ChartTooltip';
 import { CHART } from '../lib/chartColors';
 import { buildNetWorthSeries } from '../lib/netWorth';
+import { lastNMonthKeys } from '../lib/date';
 import { sumSavings } from '../lib/equity';
 import { sumDiscretionarySpent } from '../lib/spentTotals';
 import { formatSignedPct } from '../lib/format';
@@ -137,8 +138,7 @@ const DashboardPage: React.FC = () => {
   // so the chip/chart can't track a different number than the figure they sit
   // next to. Estimated points turn real as monthly snapshots accumulate.
   const { netWorthSeries, isEstimated } = useMemo(() => {
-    const monthKeys = Array.from({ length: 12 }, (_, i) =>
-      format(subMonths(new Date(), 11 - i), 'yyyy-MM'));
+    const monthKeys = lastNMonthKeys(new Date(), 12);
     const series = buildNetWorthSeries(monthKeys, netWorthHistory, netWorth);
     return { netWorthSeries: series, isEstimated: series.some(p => p.estimated) };
   }, [netWorthHistory, netWorth]);

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -7,6 +7,8 @@ import { useFinance } from '../context/FinanceContext';
 import ChartTooltip from '../components/ChartTooltip';
 import { AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import { calcTaxByRegion, IPS_MAX_DEDUCTION } from '../lib/norwegianTax';
+import { calcMonthlyPayment } from '../lib/calculations';
+import { pensionFutureValue } from '../lib/pension';
 import { currentMonthKey } from '../lib/date';
 import { salaryAt } from '../lib/salary';
 
@@ -46,14 +48,8 @@ const ForecastPage: React.FC = () => {
       : 0;
     const otpAnnual = (currentGross + currentOnCall) * (pension.otpEmployerPct + pension.otpEmployeePct) / 100;
     const ipsAnnual = Math.min(pension.ipsAnnualContribution, IPS_MAX_DEDUCTION);
-    const futureValue = (start: number, contrib: number, rate: number, n: number) => {
-      const r = rate / 100;
-      if (n <= 0) return start;
-      if (Math.abs(r) < 1e-9) return start + contrib * n;
-      return start * Math.pow(1 + r, n) + contrib * (Math.pow(1 + r, n) - 1) / r;
-    };
-    const otpAtRetire = futureValue(pension.otpBalance, otpAnnual, pension.otpGrowthRate, yearsToRetire);
-    const ipsAtRetire = futureValue(pension.ipsBalance, ipsAnnual, pension.ipsGrowthRate, yearsToRetire);
+    const otpAtRetire = pensionFutureValue(pension.otpBalance, otpAnnual, pension.otpGrowthRate, yearsToRetire);
+    const ipsAtRetire = pensionFutureValue(pension.ipsBalance, ipsAnnual, pension.ipsGrowthRate, yearsToRetire);
     return {
       hasBirthYear,
       yearsToRetire,
@@ -78,17 +74,15 @@ const ForecastPage: React.FC = () => {
   // would forecast a hypothetical first-buyer loan instead of their actual one.
   const isHomeowner = housingMode === 'homeowner';
   const startingMortgage = (isHomeowner ? homeowner.currentMortgageBalance : loan.laanebelop) ?? 0;
-  const mortgageRate = ((isHomeowner ? homeowner.rente : loan.rente) ?? 5) / 100;
+  const mortgageRatePct = (isHomeowner ? homeowner.rente : loan.rente) ?? 5;
+  const mortgageRate = mortgageRatePct / 100;
   const mortgageTermYears = (isHomeowner ? homeowner.nedbetalingstid : loan.nedbetalingstid) ?? 25;
-  // Annual mortgage payment = annuitet
-  const annualMortgagePayment = useMemo(() => {
-    if (!startingMortgage || mortgageTermYears <= 0) return 0;
-    const r = mortgageRate;
-    const n = mortgageTermYears;
-    // A 0% rate has no annuity denominator — pay the principal off linearly.
-    if (r <= 0) return startingMortgage / n;
-    return (startingMortgage * r) / (1 - Math.pow(1 + r, -n));
-  }, [startingMortgage, mortgageRate, mortgageTermYears]);
+  // Annual mortgage payment = 12 × the shared monthly annuity, so the forecast
+  // uses the same payment as the Loan page rather than re-deriving it annually.
+  const annualMortgagePayment = useMemo(
+    () => calcMonthlyPayment(startingMortgage, mortgageRatePct, mortgageTermYears) * 12,
+    [startingMortgage, mortgageRatePct, mortgageTermYears],
+  );
 
   // Forecast series
   const projection = useMemo(() => {

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -183,23 +183,24 @@ const LoanPage: React.FC = () => {
     </span>
   );
 
+  const amortizationSchedule = useMemo(
+    () => calcAmortizationSchedule(loan.laanebelop, loan.rente, loan.nedbetalingstid),
+    [loan.laanebelop, loan.rente, loan.nedbetalingstid]
+  );
+  const chartData = amortizationSchedule.filter((_, i) => i % Math.ceil(amortizationSchedule.length / 15) === 0 || i === amortizationSchedule.length - 1);
+
   // First-buyer calculations
   const calc = useMemo(() => {
-    const monthlyRate = loan.rente / 100 / 12;
     const n = loan.nedbetalingstid * 12;
     // Shared helper (guards term ≤ 0 → 0, avoiding Infinity/NaN); do not inline
     // the annuity formula here — see calculations.ts:calcMonthlyPayment.
     const monthlyPaymentBase = calcMonthlyPayment(loan.laanebelop, loan.rente, loan.nedbetalingstid);
     const monthlyPaymentWithFee = monthlyPaymentBase + loan.termingebyr;
-    const totalInterest = monthlyPaymentBase * n - loan.laanebelop;
+    // Interest from the real amortization schedule, not monthlyPayment × n −
+    // principal, which goes negative when the term is 0 (allowed by the editor).
+    const yearOneInterest = amortizationSchedule[0]?.interestPaid ?? 0;
+    const totalInterest = amortizationSchedule.reduce((s, y) => s + y.interestPaid, 0);
     const totalCost = loan.laanebelop + totalInterest + loan.etableringsgebyr + loan.termingebyr * n;
-    let balance = loan.laanebelop;
-    let yearOneInterest = 0;
-    for (let i = 0; i < 12; i++) {
-      const interest = balance * monthlyRate;
-      yearOneInterest += interest;
-      balance -= (monthlyPaymentBase - interest);
-    }
     const taxDeduction = yearOneInterest * (loan.skattefradragssats / 100);
     // Real Norwegian lending limits: the affordable price is the lower of the
     // 5× income cap and the 15%-equity (85% LTV) cap, plus a +3pp stress test.
@@ -208,13 +209,7 @@ const LoanPage: React.FC = () => {
     );
     const totalpris = loan.betingetLaan + loan.egenkapital;
     return { monthlyPaymentBase, monthlyPaymentWithFee, totalInterest, totalCost, yearOneInterest, taxDeduction, capacity, totalpris };
-  }, [loan, effArslonn, effEgenkapital, effGjeld]);
-
-  const amortizationSchedule = useMemo(
-    () => calcAmortizationSchedule(loan.laanebelop, loan.rente, loan.nedbetalingstid),
-    [loan.laanebelop, loan.rente, loan.nedbetalingstid]
-  );
-  const chartData = amortizationSchedule.filter((_, i) => i % Math.ceil(amortizationSchedule.length / 15) === 0 || i === amortizationSchedule.length - 1);
+  }, [loan, effArslonn, effEgenkapital, effGjeld, amortizationSchedule]);
 
   // Homeowner calculations
   const homeownerStatus = useMemo(

--- a/src/pages/PensionPage.tsx
+++ b/src/pages/PensionPage.tsx
@@ -11,6 +11,7 @@ import { RestoreDefaultsButton } from '../components/ui/RestoreDefaultsButton';
 import { ProvenanceBadge } from '../components/ui/ProvenanceBadge';
 import { provenanceOf } from '../lib/provenance';
 import { parseLocaleNumber } from '../lib/validators';
+import { projectPensionWealth } from '../lib/pension';
 import { currentMonthKey } from '../lib/date';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
@@ -50,24 +51,16 @@ const PensionPage: React.FC = () => {
   const ipsTaxSaving = ipsAnnualContribution * ipsDeductionRate;
 
   // Year-by-year projection.
-  const projection = useMemo(() => {
-    const out: { year: number; otp: number; ips: number; total: number }[] = [];
-    let otp = pension.otpBalance;
-    let ips = pension.ipsBalance;
-    const otpRate = pension.otpGrowthRate / 100;
-    const ipsRate = pension.ipsGrowthRate / 100;
-    for (let y = 0; y <= yearsToRetire; y++) {
-      out.push({
-        year: currentYear + y,
-        otp: Math.round(otp),
-        ips: Math.round(ips),
-        total: Math.round(otp + ips),
-      });
-      otp = otp * (1 + otpRate) + otpAnnualContribution;
-      ips = ips * (1 + ipsRate) + ipsAnnualContribution;
-    }
-    return out;
-  }, [pension, yearsToRetire, otpAnnualContribution, ipsAnnualContribution, currentYear]);
+  const projection = useMemo(() => projectPensionWealth({
+    otpBalance: pension.otpBalance,
+    ipsBalance: pension.ipsBalance,
+    otpAnnualContribution,
+    ipsAnnualContribution,
+    otpGrowthRate: pension.otpGrowthRate,
+    ipsGrowthRate: pension.ipsGrowthRate,
+    yearsToRetire,
+    startYear: currentYear,
+  }), [pension, yearsToRetire, otpAnnualContribution, ipsAnnualContribution, currentYear]);
 
   const atRetirement = projection.length > 0 ? projection[projection.length - 1] : null;
   const totalNow = pension.otpBalance + pension.ipsBalance;

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -42,7 +42,7 @@ import ChartTooltip from '../components/ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
 import { calcTaxByRegion } from '../lib/norwegianTax';
 import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from '../lib/date';
-import { salaryAt, hoursAt } from '../lib/salary';
+import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH } from '../lib/salary';
 import { formatSignedPct } from '../lib/format';
 import { isValidYearMonth, isValidYearMonthDay, isOptionalYearMonth, isPositiveNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 
@@ -51,8 +51,6 @@ const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[v
 
 const TaxBreakdownChart = lazy(() => import('../components/charts/TaxBreakdownChart'));
 const MoneyFlowSankey = lazy(() => import('../components/charts/MoneyFlowSankey'));
-
-const WEEKS_PER_MONTH = 4.345;
 
 const CHANGE_TYPE_COLOR: Record<SalaryChangeType, string> = {
   initial: 'var(--text-dim)',
@@ -151,8 +149,7 @@ const SalaryPage: React.FC = () => {
       const onCallAnnual = job?.onCallAnnual ?? 0;
       const onCallMonthly = onCallAnnual / 12;
       const totalAnnual = grossAnnual + onCallAnnual;
-      // Nominal hourly uses total earnings — on-call is regular pay for the hours worked.
-      const nominalHourly = hours > 0 ? (monthlyGross + onCallMonthly) / (WEEKS_PER_MONTH * hours) : 0;
+      const nominalHourly = nominalHourlyRate(monthlyGross, onCallMonthly, hours);
       const cpi = cpiByMonth.get(month) ?? null;
       const realHourly = cpi && baseCpi ? nominalHourly * (baseCpi / cpi) : null;
       return { month, grossAnnual, totalAnnual, monthlyGross, onCallMonthly, hoursPerWeek: hours, nominalHourly, realHourly, cpiIndex: cpi };


### PR DESCRIPTION
## Why

Three medium-priority cleanup items from `IMPROVEMENTS.md` (the 2026-07-07 maths/value-population audit). Two carried latent bugs; the rest is duplication that risked drift between surfaces.

## What

**8.5 — shared 12-month cashflow series (`1ffc78f`)**
`CashflowChart` and `SavingsRateChart` hand-rolled the same month grid, income fallback and spend filter. Extracted `monthlyCashflow()` + the `isSpend(tx)` predicate into `src/lib/monthlyCashflow.ts`, and `lastNMonthKeys(anchor, n)` into `src/lib/date.ts`. Converged both charts plus `CategoryTrendChart`, `MonthlyAccountSpend`, `DashboardPage`'s net-worth grid and `FinanceContext.incomeSeries`. Output byte-identical.

**5.1 — inline maths extraction + two bug fixes (`7e4d8b9`)**
- Bug: `hoursAt` now filters hours snapshots by the active job's `jobId`, so an ended job's part-time snapshot no longer leaks into a later job's hourly rate (unassigned snapshots stay global).
- Bug: Loan `totalInterest` now derives from the amortization schedule instead of `monthlyPayment * n - principal`, which went negative (= -principal) when the term was 0 (allowed by the editor).
- Extractions: `pension.ts` (`pensionFutureValue` + `projectPensionWealth`, shared by Pension and Forecast pages); Forecast annual mortgage payment = 12 x the shared `calcMonthlyPayment`; `salary.ts` gains `WEEKS_PER_MONTH` + `nominalHourlyRate`; Dashboard magic constants named.

**8.4 — makeCrud factory (`f0d620a`)**
`makeCrud<T>(setter, prefix)` collapses the identical add/update/remove triple across jobs, salaries, bonuses, overtime, hoursSnapshots, goals and savingsAccounts. Each binds it once via `useMemo` so the actions keep stable identity (the memoized-context contract). `removeJob`'s salary cascade and `addSavingsAccount`'s `(name, balance)` signature are preserved. Behavior unchanged.

## Verification

`npx tsc -b && npm run lint && npm test` (380 passing, incl. new tests for `monthlyCashflow`, `lastNMonthKeys`, `pension`, `hoursAt` job filtering, `nominalHourlyRate`) and `npm run build`, all green at each commit.

Not run: `make build` + live browser pass. Changes are value-preserving (plus the two intentional bug fixes) and covered by unit tests, but the Loan/Forecast/Pension number changes and the Salary/Assets/Goals CRUD actions have not been eyeballed in-app.

Residual (tracked in IMPROVEMENTS.md 5.1): SalaryPage `trailingHourly` remains an inline page-level aggregation.
