### PR TITLE
fix(bank): reject dateless rows, infer refund direction without an indicator (IMPROVEMENTS 5.7)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -376,10 +376,10 @@ of CHART values). CSS contexts where `var()` would already work: `FunBudget`,
   `DEFAULT_ASSETS`/`DEFAULT_PENSION` (loan/homeowner/transition keep zero literals — their
   DEFAULT_* constants hold non-zero example values, wrong for a wipe).
 - `server/bank.js` — ✅ FINISHED (f43420f) session/pending/config JSON writes are now
-  atomic (tmp+rename). Still open: `pickDate` (`bank.js:281`) falls back to `''`, storing
-  rows invisible to every month filter and undeletable via UI, and a feed omitting
-  `credit_debit_indicator` (`bank.js:293-306`) records refunds as positive expenses
-  (`amount: Math.abs(parsed)` + kind solely from `indicator === 'CRDT'`).
+  atomic (tmp+rename). ✅ FINISHED (86864fe) `mapEBTransaction` now rejects a row with no
+  usable date (was storing `date:''`, invisible to month filters and undeletable) and infers
+  direction from the amount sign when `credit_debit_indicator` is absent (was recording
+  refunds as positive expenses); both covered in `src/lib/bank.test.ts`.
 
 ---
 

--- a/server/bank.js
+++ b/server/bank.js
@@ -345,14 +345,26 @@ function mapEBTransaction(tx, opts = {}) {
   if (raw == null || String(raw).trim() === '' || !Number.isFinite(parsed)) {
     throw new Error(`unparseable amount: ${raw}`);
   }
+  // A row with no date at all would store as date:'' — invisible to every
+  // 'YYYY-MM' month filter and so undeletable in the UI. Reject it like a bad
+  // amount; mapEBTransactions skips it rather than let it poison the ledger.
+  const date = pickDate(tx);
+  if (!date) throw new Error('transaction has no usable date');
   const merchant = pickMerchant(tx);
   const mcc = tx.merchant_category_code != null ? String(tx.merchant_category_code) : undefined;
+  // Direction: honour the explicit indicator; if a feed omits it, fall back to
+  // the amount sign (statement convention: inflow positive, outflow negative),
+  // so a refund with no indicator counts as income, not a positive expense.
+  const indicator = tx.credit_debit_indicator;
+  const kind = indicator === 'CRDT' ? 'income'
+    : indicator === 'DBIT' ? 'expense'
+      : (parsed < 0 ? 'expense' : 'income');
   return {
     id: stableId(tx, prefix),
-    date: pickDate(tx),
+    date,
     description: pickDescription(tx),
     amount: Math.abs(parsed),
-    kind: tx.credit_debit_indicator === 'CRDT' ? 'income' : 'expense',
+    kind,
     // Richer bank-feed fields the client categorizer consumes. Categorization
     // itself is client-side; the server never assigns a category.
     ...(merchant ? { merchant } : {}),

--- a/src/lib/bank.test.ts
+++ b/src/lib/bank.test.ts
@@ -84,6 +84,21 @@ describe('mapEBTransaction', () => {
     expect(mapEBTransaction(tx({ booking_date: undefined, value_date: undefined, transaction_date: '2026-05-02' })).date).toBe('2026-05-02');
   });
 
+  it('throws when the feed carries no usable date (would be invisible/undeletable)', () => {
+    expect(() => mapEBTransaction(tx({ booking_date: undefined, value_date: undefined, transaction_date: undefined }))).toThrow();
+  });
+
+  it('infers direction from the amount sign when the indicator is absent', () => {
+    // A refund with no credit_debit_indicator is income (positive), not a
+    // positive expense; a purchase with no indicator stays an expense.
+    const refund = mapEBTransaction(tx({ credit_debit_indicator: undefined, transaction_amount: { currency: 'NOK', amount: '200.00' } }));
+    expect(refund.kind).toBe('income');
+    expect(refund.amount).toBe(200);
+    const purchase = mapEBTransaction(tx({ credit_debit_indicator: undefined, transaction_amount: { currency: 'NOK', amount: '-149.90' } }));
+    expect(purchase.kind).toBe('expense');
+    expect(purchase.amount).toBe(149.9);
+  });
+
   it('stamps account/bank/accountName from opts, and omits them when absent', () => {
     const tagged = mapEBTransaction(tx(), { account: 'abcd1234:uid-1', bank: 'Handelsbanken', accountName: 'Brukskonto' });
     expect(tagged.account).toBe('abcd1234:uid-1');


### PR DESCRIPTION
## Why

Two ingest-correctness bugs from `IMPROVEMENTS.md` 5.7, both in `mapEBTransaction` (`server/bank.js`). Neither is theoretical: each silently corrupts the ledger for a bank whose feed omits a field.

## What

- **Dateless rows.** `pickDate` fell back to `''`, so a row with no booking/value/transaction date was stored with `date: ''` — invisible to every `YYYY-MM` month filter and impossible to delete in the UI. Now rejected like a bad amount; `mapEBTransactions` skips it rather than poisoning the ledger.
- **Refund sign.** `kind` came solely from `credit_debit_indicator === 'CRDT'`, so a feed that omits the indicator recorded refunds (credits) as positive expenses. Now honours an explicit `DBIT`/`CRDT`, and otherwise falls back to the amount sign (statement convention: inflow positive, outflow negative).

## Verification

`npx tsc -b && npm run lint && npm test` — 382 passing, including new `src/lib/bank.test.ts` cases for the dateless-row rejection and the indicator-absent direction inference. Existing DBIT/CRDT behaviour is unchanged (covered by the pre-existing tests). Server-only change, no UI surface.
