### PR TITLE
refactor(server): readBlob() + bankRoute wrapper (IMPROVEMENTS 8.9)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -558,7 +558,13 @@ so a slot component would be a bigger abstraction than the duplication it remove
 same alignment spacer; they differ only in trailing extras (notes/reset, trash, icon).
 Fix: one `ui/EditableRow` with slots.
 
-**8.9 🟢 Server boilerplate in `server/index.js`.**
+**8.9 ✅ FINISHED (92c8809) Server boilerplate in `server/index.js`.**
+(`readBlob(id)` centralizes the `getStmt.get` + `JSON.parse` from `/api/data`,
+`reconcileBankTransactions`, `preserveUserFields` and `/api/bank/sync`, guarding the parse
+that was unguarded in the last — a corrupt blob now 409s the sync instead of 500-crashing.
+`/api/data` POST keeps `getStmt`: it needs only the rev. `bankRoute(status, handler)` removes
+the identical try/catch from the five uniform bank routes; the callback redirect and sync's
+`needsRelink` 409 stay bespoke.)
 Blob read (`getStmt.get('headroom')` + `JSON.parse`) repeated at :177-185, :206-214, and
 :388-390 (the last one, in `/api/bank/sync`, has an unguarded parse); extract `readBlob()`.
 Seven bank routes repeat the same try/catch-to-status wrapper (:317-414); a tiny handler

--- a/server/index.js
+++ b/server/index.js
@@ -110,6 +110,20 @@ function writeBlob(id, content, prevRev) {
   return rev;
 }
 
+// Read + parse the single stored finance blob. Returns { content, rev } or null
+// when the row is missing or its JSON is corrupt — callers decide the fallback
+// (send null, keep the incoming payload, or 409). Guards the parse that was
+// previously unguarded in /api/bank/sync.
+function readBlob(id = 'headroom') {
+  const row = getStmt.get(id);
+  if (!row) return null;
+  try {
+    return { content: JSON.parse(row.content), rev: row.rev };
+  } catch {
+    return null;
+  }
+}
+
 const inflationGetRange = db.prepare(
   'SELECT month, cpi_index AS cpiIndex, fetched_at AS fetchedAt FROM inflation_cache WHERE month >= ? AND month <= ? ORDER BY month ASC'
 );
@@ -150,10 +164,10 @@ app.get('/healthz', (_req, res) => {
 });
 
 app.get('/api/data', (req, res) => {
-  const row = getStmt.get('headroom');
+  const blob = readBlob();
   // The client echoes this rev back on save so we can detect a stale write.
-  res.set('X-Data-Rev', String(row ? row.rev : 0));
-  res.json(row ? JSON.parse(row.content) : null);
+  res.set('X-Data-Rev', String(blob ? blob.rev : 0));
+  res.json(blob ? blob.content : null);
 });
 
 // Minimal shape check so a stray/garbage POST can't overwrite the single data
@@ -183,14 +197,9 @@ const EB_ID_PREFIX = bank.EB_ID_PREFIX;
 // clobbered. (Trade-off: deleting an imported row in the UI can resurrect it —
 // tracked in BACKLOG.md.)
 function reconcileBankTransactions(incoming) {
-  const row = getStmt.get('headroom');
-  if (!row) return incoming;
-  let stored;
-  try {
-    stored = JSON.parse(row.content);
-  } catch {
-    return incoming;
-  }
+  const blob = readBlob();
+  if (!blob) return incoming;
+  const stored = blob.content;
   const storedTx = Array.isArray(stored.dailyTransactions) ? stored.dailyTransactions : [];
   const incomingTx = Array.isArray(incoming.dailyTransactions) ? incoming.dailyTransactions : [];
   const incomingIds = new Set(incomingTx.map((t) => t && t.id));
@@ -215,14 +224,9 @@ function reconcileBankTransactions(incoming) {
 // respected (that's an intentional clear); only a missing field falls back to
 // the stored value.
 function preserveUserFields(incoming) {
-  const row = getStmt.get('headroom');
-  if (!row) return incoming;
-  let stored;
-  try {
-    stored = JSON.parse(row.content);
-  } catch {
-    return incoming;
-  }
+  const blob = readBlob();
+  if (!blob) return incoming;
+  const stored = blob.content;
   const out = { ...incoming };
   for (const field of ['accountLabels', 'categoryRules', 'labelRules', 'categoryBudgets', 'deletedBankIds']) {
     const hasStored = stored[field] && (Array.isArray(stored[field]) ? stored[field].length : Object.keys(stored[field]).length);
@@ -341,73 +345,66 @@ app.get('/api/wage-stats', (_req, res) => {
 // ── Bank sync (Enable Banking) ───────────────────────────────────
 // Drives the in-app link/re-link/sync flow. Engine in server/bank.js.
 
+// Wrap a bank route so a thrown error becomes `status` + { error: message }
+// instead of a repeated try/catch. Server faults (5xx) are logged; client
+// faults (4xx) aren't. Routes with bespoke error handling — the callback
+// redirect and sync's needsRelink 409 — keep their own try/catch.
+function bankRoute(status, handler) {
+  return async (req, res) => {
+    try {
+      await handler(req, res);
+    } catch (err) {
+      if (status >= 500) console.error(`[bank] ${req.path} failed:`, err.message);
+      res.status(status).json({ error: err.message });
+    }
+  };
+}
+
 app.get('/api/bank/status', (_req, res) => {
   res.json(bank.getStatus());
 });
 
 // The connectable banks for the picker (proxied so the client never needs the key).
-app.get('/api/bank/aspsps', async (_req, res) => {
-  try {
-    res.json({ aspsps: await bank.getAspsps() });
-  } catch (err) {
-    console.error('[bank] aspsps failed:', err.message);
-    res.status(500).json({ error: err.message });
-  }
-});
+app.get('/api/bank/aspsps', bankRoute(500, async (_req, res) => {
+  res.json({ aspsps: await bank.getAspsps() });
+}));
 
 // Disconnect one bank. Its already-imported rows stay in the ledger.
-app.delete('/api/bank/connection/:id', (req, res) => {
-  try {
-    res.json({ ok: true, ...bank.removeConnection(String(req.params.id)), ...bank.getStatus() });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+app.delete('/api/bank/connection/:id', bankRoute(400, (req, res) => {
+  res.json({ ok: true, ...bank.removeConnection(String(req.params.id)), ...bank.getStatus() });
+}));
 
 // Upload the app's private key (write-only — never read back). Validates the
 // PEM and verifies it against Enable Banking before storing it (chmod 600,
 // encrypted at rest when EB_KEY_SECRET is set).
-app.post('/api/bank/key', async (req, res) => {
-  try {
-    const pem = req.body && req.body.pem;
-    if (typeof pem !== 'string' || !pem.includes('PRIVATE KEY')) {
-      return res.status(400).json({ error: 'expected a PEM private key' });
-    }
-    const { verified, encrypted } = await bank.saveKey(pem);
-    res.json({ ok: true, verified, encrypted, ...bank.getStatus() });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
+app.post('/api/bank/key', bankRoute(400, async (req, res) => {
+  const pem = req.body && req.body.pem;
+  if (typeof pem !== 'string' || !pem.includes('PRIVATE KEY')) {
+    return res.status(400).json({ error: 'expected a PEM private key' });
   }
-});
+  const { verified, encrypted } = await bank.saveKey(pem);
+  res.json({ ok: true, verified, encrypted, ...bank.getStatus() });
+}));
 
 // Set non-secret bank settings stored server-side: the redirect (callback)
 // URL and/or the Enable Banking application ID. Each is applied only when
 // present in the body, so the client can save them independently.
-app.post('/api/bank/config', (req, res) => {
-  try {
-    const body = req.body || {};
-    if (body.redirectUrl !== undefined) bank.setRedirect(String(body.redirectUrl || ''));
-    if (body.appId !== undefined) bank.setAppId(String(body.appId || ''));
-    res.json({ ok: true, ...bank.getStatus() });
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
-});
+app.post('/api/bank/config', bankRoute(400, (req, res) => {
+  const body = req.body || {};
+  if (body.redirectUrl !== undefined) bank.setRedirect(String(body.redirectUrl || ''));
+  if (body.appId !== undefined) bank.setAppId(String(body.appId || ''));
+  res.json({ ok: true, ...bank.getStatus() });
+}));
 
 // Start BankID for the chosen bank: returns the redirect url the client sends the browser to.
-app.post('/api/bank/link', async (req, res) => {
-  try {
-    const aspsp = req.body && req.body.aspsp;
-    const connectionId = req.body && req.body.connectionId;
-    res.json(await bank.startLink(
-      typeof aspsp === 'string' ? aspsp : undefined,
-      typeof connectionId === 'string' ? connectionId : undefined,
-    ));
-  } catch (err) {
-    console.error('[bank] link failed:', err.message);
-    res.status(500).json({ error: err.message });
-  }
-});
+app.post('/api/bank/link', bankRoute(500, async (req, res) => {
+  const aspsp = req.body && req.body.aspsp;
+  const connectionId = req.body && req.body.connectionId;
+  res.json(await bank.startLink(
+    typeof aspsp === 'string' ? aspsp : undefined,
+    typeof connectionId === 'string' ? connectionId : undefined,
+  ));
+}));
 
 // BankID redirect lands here; exchange the code, save the session, bounce to Settings.
 app.get('/api/bank/callback', async (req, res) => {
@@ -425,9 +422,9 @@ app.get('/api/bank/callback', async (req, res) => {
 app.post('/api/bank/sync', async (_req, res) => {
   try {
     const mapped = await bank.fetchMappedTransactions();
-    const row = getStmt.get('headroom');
-    if (!row) return res.status(409).json({ error: 'no finance data yet — open the app first' });
-    const blob = JSON.parse(row.content);
+    const stored = readBlob();
+    if (!stored) return res.status(409).json({ error: 'no finance data yet — open the app first' });
+    const blob = stored.content;
     const existing = Array.isArray(blob.dailyTransactions) ? blob.dailyTransactions : [];
     const before = existing.length;
     const deletedIds = Array.isArray(blob.deletedBankIds) ? blob.deletedBankIds : [];
@@ -435,7 +432,7 @@ app.post('/api/bank/sync', async (_req, res) => {
     // Bump rev so *other* open tabs see the change and refetch the freshly-synced
     // rows. We return the new rev so the tab that triggered the sync can adopt it
     // and not treat its own sync as a conflicting external change.
-    const newRev = writeBlob('headroom', JSON.stringify(blob), row.rev);
+    const newRev = writeBlob('headroom', JSON.stringify(blob), stored.rev);
     bank.recordSync();
     res.set('X-Data-Rev', String(newRev));
     res.json({


### PR DESCRIPTION
## Why

`IMPROVEMENTS.md` 8.9 — server boilerplate. The stored-blob read (`getStmt.get` + `JSON.parse`) was copy-pasted across four handlers, and the copy in `/api/bank/sync` was **unguarded**: a corrupt stored blob would throw inside the route and 500-crash the sync. Seven bank routes also repeated the same try/catch-to-status block.

## What

- **`readBlob(id)`** centralizes read + parse and returns `{ content, rev }` or `null` on a missing/corrupt row, so callers pick the fallback (send null, keep incoming, or 409). Applied to `/api/data`, `reconcileBankTransactions`, `preserveUserFields`, and `/api/bank/sync`. The now-guarded parse means a corrupt blob makes the sync return a clean 409 instead of crashing. `/api/data` POST intentionally keeps `getStmt` — it needs only the rev, not the parsed content.
- **`bankRoute(status, handler)`** removes the identical try/catch from the five uniform bank routes (aspsps, connection, key, config, link); server faults (5xx) still log, client faults (4xx) don't. The callback redirect and sync's `needsRelink` 409 keep bespoke handling.

Behavior is unchanged except the bank/sync corrupt-blob path, which now 409s instead of 500ing.

## Verification

`npx tsc -b && npm run lint && npm test` (382 passing). Throwaway-`DATA_DIR` server smoke: boots cleanly, `GET /api/data` round-trips through `readBlob` (correct `X-Data-Rev` + null-when-empty), `/api/bank/sync` responds gracefully. The POST-write path can't be exercised in this sandbox (sqlite writes are blocked at the filesystem level, independent of this change — `writeBlob` is untouched).
