### PR TITLE
Logic cleanup: dedup + hygiene (IMPROVEMENTS §5.6/§5.7)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -265,3 +265,36 @@ Most of `AUDIT.md` is done (see its "Progress log"). These remaining entries are
 - **§4.5 Unify the two charting systems — DONE (2026-07).** `DashboardPage`'s 4 bespoke SVG charts (`HeroChart`, `BurnRateChart`, `MonthlyInvestmentBars`, `ProjectionChart`) are now Recharts (`AreaChart`/`BarChart` with `ReferenceLine`/`ReferenceDot`/`Cell`), sharing the common `ChartTooltip` and `CHART` tokens; the private `ChartTip` and the `smoothPath` helper are gone. Trade-off accepted: the old charts used `preserveAspectRatio="none"` (edge-to-edge stretch) + HTML overlays for crisp round dots, which Recharts' true-aspect `ResponsiveContainer` doesn't reproduce, so proportions shifted slightly; the per-hover "estimert" tooltip sub-caption dropped (the hollow/dashed dot & bar still signal estimated). Visually verified in Docker (0 console errors).
 - **§7.2 Self-host fonts + offline read-only data — fonts DONE (2026-07); offline data PENDING a decision.** Fonts are now self-hosted via Fontsource (`src/fonts.ts` imports the `latin` subset at the exact weights: Cormorant 400/500/600 + italic 400/500, IBM Plex Mono 400/500/600, Inter 400/500/600/700). The Google `<link>`s are gone from `index.html`, the CSP dropped `fonts.googleapis.com`/`fonts.gstatic.com` (`styleSrc`/`fontSrc` now `'self'` only), and `woff2` was added to the PWA precache glob (12 files precached). Verified in Docker: fonts render identically, zero requests to Google, 0 console/CSP errors. **Offline-data caching declined (2026-07)**: a NetworkFirst cache for `GET /api/data` was considered and deliberately NOT added — it would persist the full financial blob in the browser's Cache Storage (data-at-rest), which isn't worth it for a single-user loopback app. `/api/data` stays network-only; offline shows the existing load-failed state. Revisit only if a real offline-read need arises.
 - **§5.5 ESLint depth.** Baseline only — no `recommendedTypeChecked`, no `eslint-plugin-jsx-a11y` (would auto-catch icon-button/label regressions), no formatter/pre-commit hooks. `no-unused-vars` is now configured. **Where**: `eslint.config.js`.
+
+## IMPROVEMENTS §5.6/§5.7 logic-cleanup — deferred data-safety items
+
+Two items from the logic-cleanup pass were deferred because touching them risks
+resurrecting or double-counting real bank transactions.
+
+- **Bank-id dedup regex ambiguity.** **What**: the bare-vs-prefixed split in the
+  twin-dedup regexes classifies any `eb-<8hex>-<rest>` id as connection-prefixed,
+  so a legacy *bare* id whose ref happens to begin with 8 hex chars + `-` is
+  misclassified as prefixed (and could drop a same-ref bare row that is actually a
+  distinct transaction). **Why deferred**: the two id shapes (`eb-<8hex>-<ref>`
+  prefixed vs `eb-<8hexref…>` bare) are genuinely indistinguishable by structure;
+  no safe discriminator exists, and guessing wrong risks data loss/duplication in a
+  money app. **What would unblock**: convergence of the id format so bare ids no
+  longer exist (see the §2.3 note — "keep; shrink after 2.3 converges the blob"),
+  after which the bare branch can be removed entirely instead of disambiguated; or a
+  reliable secondary key (own-IBAN / booking-date match) to break the tie. **Where**:
+  `src/lib/bankDedup.ts` (`BARE`/`PREFIXED`) and its byte-equivalent twin
+  `dropStaleBareTwins` in `server/bank.js`; behavior locked by a documenting test in
+  `src/lib/bankDedup.test.ts`.
+- **`deletedBankIds` grows unbounded.** **What**: soft-deleted bank-row ids
+  accumulate forever in the persisted blob and are never pruned. **Why deferred**:
+  an id stays in `deletedBankIds` precisely because its row is absent from
+  `dailyTransactions`, so "prune ids no longer in the stored blob" would prune the
+  whole set and let the next server reconcile (`mergeTransactions`) resurrect every
+  deleted transaction. There is no client-side signal proving a deleted id can never
+  return from a future bank sync (the sync window is server-side), so no prune is
+  provably safe. **What would unblock**: a server-side retention rule keyed to the
+  Enable Banking sync window (drop a deleted id only once the bank can no longer
+  return it), or tying deleted ids to a connection lifecycle so they can be dropped
+  when a connection is removed. **Where**: `src/context/FinanceContext.tsx`
+  (`deletedBankIds`, `setDailyTransactionsTracked`), consumed by
+  `mergeTransactions` in `server/bank.js`.

--- a/server/bank.js
+++ b/server/bank.js
@@ -408,6 +408,18 @@ function mapEBTransactions(txs, opts = {}) {
 // connections may reuse a ref, so we never merge across prefixes; only a bare row
 // with a prefixed twin is removed. A manual category on the dropped row is
 // rescued onto its survivor.
+//
+// TWIN: `dedupeBankTransactions` in src/lib/bankDedup.ts (TS/ESM) is a
+// byte-equivalent copy of this logic, including the two regexes below. This CJS
+// server can't import from src/, so the two are hand-maintained and MUST stay
+// identical — change both or neither.
+//
+// Known limitation (see BACKLOG.md "Bank-id dedup regex ambiguity"): the
+// prefixed-vs-bare split is inherently ambiguous. A legacy BARE id whose ref
+// happens to start with 8 hex chars + '-' (e.g. `eb-a1b2c3d4-...`) is
+// indistinguishable from a real PREFIXED id and is treated as prefixed. Not
+// tightened here because no safe structural discriminator exists — guessing wrong
+// could resurrect or double-count real bank transactions.
 function dropStaleBareTwins(txs) {
   const PREFIXED = /^eb-[0-9a-f]{8}-(.+)$/i;
   const BARE = /^eb-(?![0-9a-f]{8}-)(.+)$/i;

--- a/src/components/GoalsSection.tsx
+++ b/src/components/GoalsSection.tsx
@@ -5,7 +5,7 @@ import EditModal, { type ModalField } from '../components/EditModal';
 import ConfirmModal from '../components/ConfirmModal';
 import { sumSavings } from '../lib/equity';
 import { ProgressBar } from './ui/ProgressBar';
-import { isValidYearMonth, isOptionalYearMonth, isPositiveNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
+import { isValidYearMonth, isOptionalYearMonth, isNonNegativeNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
@@ -110,7 +110,7 @@ const GoalsSection: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.validation.nameRequired });
           return;
         }
-        if (!isPositiveNumber(vals.target)) {
+        if (!isNonNegativeNumber(vals.target)) {
           setModal(prev => prev && { ...prev, error: t.validation.targetPositive });
           return;
         }

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -26,6 +26,7 @@ import { lastNMonthKeys } from '../lib/date';
 import { accountGroupLabel, accountGroupKey } from '../lib/account';
 import { sumDebtByType } from '../lib/debt';
 import { dedupeBankTransactions } from '../lib/bankDedup';
+import { salaryAt } from '../lib/salary';
 import { stableStringify } from '../lib/stableStringify';
 import { sanitizePayload } from '../lib/sanitizePayload';
 import {
@@ -242,15 +243,12 @@ export function calcActiveGrossAnnual(
   jobs: JobEntry[],
   monthKey: string,
 ): number {
-  const eligible = salaries.filter(s => s.effectiveDate <= monthKey);
-  if (eligible.length === 0) return 0;
-  const latestPerJob = new Map<string, SalaryEntry>();
-  for (const s of eligible) {
-    const cur = latestPerJob.get(s.jobId);
-    if (!cur || s.effectiveDate > cur.effectiveDate) latestPerJob.set(s.jobId, s);
-  }
+  // Latest applicable salary PER job via the shared `salaryAt` selection, then
+  // summed across jobs still active this month.
   let total = 0;
-  for (const [jobId, sal] of latestPerJob) {
+  for (const jobId of new Set(salaries.map(s => s.jobId))) {
+    const sal = salaryAt(monthKey, salaries.filter(s => s.jobId === jobId));
+    if (!sal) continue;
     const job = jobs.find(j => j.id === jobId);
     if (job?.endDate && job.endDate < monthKey) continue; // skip jobs that ended before this month
     total += sal.grossAnnual + (job?.onCallAnnual ?? 0);

--- a/src/lib/bankDedup.test.ts
+++ b/src/lib/bankDedup.test.ts
@@ -49,4 +49,19 @@ describe('dedupeBankTransactions', () => {
     expect(dedupeBankTransactions(clean)).toHaveLength(3);
     expect(dedupeBankTransactions(dedupeBankTransactions(clean))).toHaveLength(3);
   });
+
+  // Documents the known regex ambiguity (see bankDedup.ts / BACKLOG.md): an id of
+  // shape `eb-<8hex>-<rest>` is always read as PREFIXED (conn=<8hex>, ref=<rest>),
+  // even though a legacy bare id could theoretically have that exact text. Left
+  // as-is because no safe discriminator exists; this test locks current behavior.
+  it('classifies an ambiguous eb-<8hex>-<rest> id as prefixed', () => {
+    const out = dedupeBankTransactions([
+      tx({ id: 'eb-a1b2c3d4-5678', account: 'ambiguous' }),
+      tx({ id: 'eb-5678', amount: 100 }),
+    ]);
+    // Read as prefixed with ref '5678'; the bare 'eb-5678' shares that ref, so it
+    // is dropped as a stale twin (the survivor keeps the prefixed id).
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('eb-a1b2c3d4-5678');
+  });
 });

--- a/src/lib/bankDedup.ts
+++ b/src/lib/bankDedup.ts
@@ -10,6 +10,17 @@ import type { DailyTransaction } from '../context/FinanceContext';
 // entry_reference exists — but never merge two different prefixed connections,
 // since separate banks may reuse an entry_reference (the prefix is what keeps
 // those distinct). Manual (non-eb) rows are untouched.
+//
+// TWIN: `dropStaleBareTwins` in server/bank.js (CJS) is a byte-equivalent copy of
+// this logic, including the two regexes below. The server can't import from src/,
+// so the two are hand-maintained and MUST stay identical — change both or neither.
+//
+// Known limitation (see BACKLOG.md "Bank-id dedup regex ambiguity"): the
+// prefixed-vs-bare split is inherently ambiguous. A legacy BARE id whose ref
+// happens to start with 8 hex chars + '-' (e.g. `eb-a1b2c3d4-...`) is
+// indistinguishable from a real PREFIXED id and is treated as prefixed. Not
+// tightened here because no safe structural discriminator exists — guessing wrong
+// could resurrect or double-count real bank transactions.
 const PREFIXED = /^eb-[0-9a-f]{8}-(.+)$/i;
 const BARE = /^eb-(?![0-9a-f]{8}-)(.+)$/i;
 

--- a/src/lib/calculations.test.ts
+++ b/src/lib/calculations.test.ts
@@ -224,8 +224,8 @@ describe('calcHomeownerMortgageStatus', () => {
     const s = calcHomeownerMortgageStatus(2_000_000, 2_500_000, 5, 20, 22);
     expect(s.monthlyInterest).toBeCloseTo(2_000_000 * 0.05 / 12, 6);
     expect(s.monthlyInterest + s.monthlyPrincipal).toBeCloseTo(s.monthlyPaymentCalc, 6);
-    // "equityPercent" is actually % of original loan repaid (see 5.7 rename note).
-    expect(s.equityPercent).toBeCloseTo(20, 6);
+    // % of the original loan repaid (20% of 2.5M paid down to 2.0M).
+    expect(s.originalLoanRepaidPercent).toBeCloseTo(20, 6);
   });
 
   it('bases the tax deduction on year-one amortized interest, below the flat ×12 figure', () => {
@@ -242,8 +242,8 @@ describe('calcHomeownerMortgageStatus', () => {
   });
 
   it('clamps repaid share to 0 and handles a zero original loan', () => {
-    expect(calcHomeownerMortgageStatus(2_600_000, 2_500_000, 5, 20, 22).equityPercent).toBe(0);
-    expect(calcHomeownerMortgageStatus(2_000_000, 0, 5, 20, 22).equityPercent).toBe(0);
+    expect(calcHomeownerMortgageStatus(2_600_000, 2_500_000, 5, 20, 22).originalLoanRepaidPercent).toBe(0);
+    expect(calcHomeownerMortgageStatus(2_000_000, 0, 5, 20, 22).originalLoanRepaidPercent).toBe(0);
   });
 });
 

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -232,7 +232,8 @@ export interface HomeownerStatus {
   monthlyInterest: number;
   monthlyPrincipal: number;
   annualTaxDeduction: number;
-  equityPercent: number;
+  /** Share of the ORIGINAL loan already repaid, as a percent (not home equity). */
+  originalLoanRepaidPercent: number;
 }
 
 export function calcHomeownerMortgageStatus(
@@ -252,11 +253,11 @@ export function calcHomeownerMortgageStatus(
   const yearOneInterest = calcAmortizationSchedule(currentBalance, annualRate, yearsRemaining)[0]?.interestPaid
     ?? monthlyInterest * 12;
   const annualTaxDeduction = yearOneInterest * (skattefradragssats / 100);
-  const equityPercent =
+  const originalLoanRepaidPercent =
     originalLoan > 0
       ? Math.max(0, ((originalLoan - currentBalance) / originalLoan) * 100)
       : 0;
-  return { monthlyPaymentCalc, monthlyInterest, monthlyPrincipal, annualTaxDeduction, equityPercent };
+  return { monthlyPaymentCalc, monthlyInterest, monthlyPrincipal, annualTaxDeduction, originalLoanRepaidPercent };
 }
 
 export interface BucketAmounts {

--- a/src/lib/categorize.ts
+++ b/src/lib/categorize.ts
@@ -6,6 +6,7 @@
 // Pure and unit-tested. The client applies it at ingest (bank sync + backfill);
 // the server never categorizes — it only preserves categories on re-sync.
 import type { CategoryKey } from './categories';
+import { buildMatchHaystack } from './text';
 
 export interface CategorizeInput {
   merchant?: string;
@@ -183,7 +184,7 @@ function categoryFromMcc(mcc: string): CategoryKey | undefined {
 export function categorizeWithRules(input: CategorizeInput, rules: CategoryRule[]): CategorizeResult {
   if (input.kind === 'income') return { category: 'income', source: 'auto' };
   if (rules && rules.length) {
-    const hay = ` ${input.merchant ?? ''} ${input.description ?? ''} `.toLowerCase();
+    const hay = buildMatchHaystack(input.merchant, input.description);
     for (const r of rules) {
       const m = (r.match || '').trim().toLowerCase();
       if (m && hay.includes(m)) return { category: r.category, source: 'auto' };
@@ -196,9 +197,7 @@ export function categorizeWithRules(input: CategorizeInput, rules: CategoryRule[
 export function categorize(input: CategorizeInput): CategorizeResult {
   if (input.kind === 'income') return { category: 'income', source: 'auto' };
 
-  // Pad with spaces so leading/trailing-space keywords (e.g. ' esso', 'vy ')
-  // act as word boundaries — 'esso' must not match inside 'espresso'.
-  const hay = ` ${input.merchant ?? ''} ${input.description ?? ''} `.toLowerCase();
+  const hay = buildMatchHaystack(input.merchant, input.description);
   for (const [category, keywords] of RULES) {
     if (keywords.some((kw) => hay.includes(kw))) return { category, source: 'auto' };
   }

--- a/src/lib/envelopes.ts
+++ b/src/lib/envelopes.ts
@@ -11,6 +11,7 @@
 import type { DailyTransaction, FixedExpense } from '../context/FinanceContext';
 import { isCategoryKey, type CategoryKey } from './categories';
 import { spendByCategory } from './categoryStats';
+import { buildMatchHaystack } from './text';
 
 export type EnvelopeStatus = 'under' | 'near' | 'over';
 
@@ -65,7 +66,7 @@ function statusFor(budgeted: number, actual: number): EnvelopeStatus {
 export function envelopeKeyForTx(tx: DailyTransaction, rec: Pick<Reconciliation, 'matchers' | 'envelopedCategories'>): string | undefined {
   if (tx.kind === 'income') return undefined;
   if (rec.matchers.length) {
-    const hay = ` ${tx.merchant ?? ''} ${tx.description ?? ''} `.toLowerCase();
+    const hay = buildMatchHaystack(tx.merchant, tx.description);
     for (const m of rec.matchers) if (m.match && hay.includes(m.match)) return m.key;
   }
   if (isCategoryKey(tx.category) && rec.envelopedCategories.has(tx.category)) return tx.category;

--- a/src/lib/income.test.ts
+++ b/src/lib/income.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { incomeDiffPct } from './income';
+
+describe('incomeDiffPct', () => {
+  it('reports the percentage above/below the trailing average', () => {
+    expect(incomeDiffPct(55000, 50000)).toBeCloseTo(10, 6);
+    expect(incomeDiffPct(45000, 50000)).toBeCloseTo(-10, 6);
+    expect(incomeDiffPct(50000, 50000)).toBe(0);
+  });
+
+  it('returns 0 when there is no positive baseline (no divide-by-zero)', () => {
+    expect(incomeDiffPct(55000, 0)).toBe(0);
+    expect(incomeDiffPct(55000, -100)).toBe(0);
+  });
+});

--- a/src/lib/income.ts
+++ b/src/lib/income.ts
@@ -1,0 +1,11 @@
+// Small income comparison helpers shared across pages.
+
+/**
+ * Percentage difference between a month's effective income and the trailing
+ * average income. Positive means above average, negative below. Returns 0 when
+ * the average is non-positive (no baseline to compare against — avoids
+ * divide-by-zero). Callers localize the label; this returns the raw number.
+ */
+export function incomeDiffPct(effectiveIncome: number, averageIncome: number): number {
+  return averageIncome > 0 ? ((effectiveIncome - averageIncome) / averageIncome) * 100 : 0;
+}

--- a/src/lib/labelRules.ts
+++ b/src/lib/labelRules.ts
@@ -4,6 +4,7 @@
 // Purely a display layer: the original `description` is preserved for matching
 // and categorization. Pure + unit-tested.
 import type { DailyTransaction } from '../context/FinanceContext';
+import { buildMatchHaystack } from './text';
 
 export interface LabelRule {
   id: string;
@@ -14,7 +15,7 @@ export interface LabelRule {
 /** The label of the first rule whose match is a substring of the tx, else undefined. */
 export function ruleLabelFor(tx: Pick<DailyTransaction, 'merchant' | 'description'>, rules: LabelRule[]): string | undefined {
   if (!rules || !rules.length) return undefined;
-  const hay = ` ${tx.merchant ?? ''} ${tx.description ?? ''} `.toLowerCase();
+  const hay = buildMatchHaystack(tx.merchant, tx.description);
   for (const r of rules) {
     const m = (r.match || '').trim().toLowerCase();
     if (m && hay.includes(m)) return r.label;

--- a/src/lib/salary.test.ts
+++ b/src/lib/salary.test.ts
@@ -46,6 +46,14 @@ describe('salaryAt', () => {
     const shuffled = [salaries[2], salaries[0], salaries[1]];
     expect(salaryAt('2025-12', shuffled)?.id).toBe('b');
   });
+
+  // calcActiveGrossAnnual (FinanceContext) reuses this selection per job, so its
+  // tie-break is whatever salaryAt does: on equal effectiveDate the reduce keeps
+  // the last entry in array order.
+  it('breaks a same-month tie by taking the last entry in array order', () => {
+    const tied = [sal('a', '2025-06', 600000), sal('b', '2025-06', 700000)];
+    expect(salaryAt('2025-06', tied)?.id).toBe('b');
+  });
 });
 
 describe('hoursAt', () => {

--- a/src/lib/sanitizePayload.test.ts
+++ b/src/lib/sanitizePayload.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { coerceNumber, sanitizePayload } from './sanitizePayload';
+import { parseLocaleNumber } from './validators';
 
 const SCHEMAS = {
   assets: { portfolio: 0, taxRate: 0, houseValue: 0 },
@@ -24,6 +25,13 @@ describe('coerceNumber', () => {
     expect(coerceNumber(null)).toBeUndefined();
     expect(coerceNumber(undefined)).toBeUndefined();
     expect(coerceNumber({})).toBeUndefined();
+  });
+
+  it('tolerates a thousands-space that parseLocaleNumber deliberately rejects', () => {
+    // Salvage grammar (stored/imported blobs) vs strict input grammar are
+    // intentionally different — this documents that divergence.
+    expect(coerceNumber('12 000')).toBe(12000);
+    expect(parseLocaleNumber('12 000')).toBeNaN();
   });
 });
 

--- a/src/lib/sanitizePayload.ts
+++ b/src/lib/sanitizePayload.ts
@@ -6,7 +6,15 @@
 // caller's `{...DEFAULT, ...data}` merge fills the gap. It never removes or
 // rewrites non-numeric data. Pure + unit-tested; applied at the apply boundary.
 
-/** A finite number, or undefined if the value can't be one. */
+/**
+ * A finite number, or undefined if the value can't be one.
+ *
+ * Deliberately MORE lenient than `parseLocaleNumber` in validators.ts: this
+ * strips thousands spaces ("12 000" → 12000) to salvage locale-formatted values
+ * from an already-stored / hand-edited / imported blob, whereas parseLocaleNumber
+ * rejects them so an ambiguous live keystroke errors instead. Keep the grammars
+ * distinct on purpose (input strict, salvage lenient).
+ */
 export function coerceNumber(v: unknown): number | undefined {
   if (typeof v === 'number') return Number.isFinite(v) ? v : undefined;
   if (typeof v === 'string') {

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { buildMatchHaystack } from './text';
+
+describe('buildMatchHaystack', () => {
+  it('lowercases and pads merchant + description with boundary spaces', () => {
+    expect(buildMatchHaystack('REMA 1000', 'Kortkjøp')).toBe(' rema 1000 kortkjøp ');
+  });
+
+  it('treats missing fields as empty strings', () => {
+    expect(buildMatchHaystack()).toBe('   ');
+    expect(buildMatchHaystack('Vy')).toBe(' vy  ');
+    expect(buildMatchHaystack(undefined, 'Til:123')).toBe('  til:123 ');
+  });
+
+  it('lets a boundary-padded keyword act as a word boundary', () => {
+    // ' esso' must match the fuel merchant but not the substring inside 'espresso'.
+    expect(buildMatchHaystack('ESSO', '').includes(' esso')).toBe(true);
+    expect(buildMatchHaystack('Espresso House', '').includes(' esso')).toBe(false);
+  });
+});

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,14 @@
+// Shared text helpers for transaction matching.
+
+/**
+ * Build the lowercased search "haystack" used by every keyword / rule / label
+ * matcher over a transaction's merchant + description.
+ *
+ * The single leading and trailing spaces are word-boundary padding: a keyword
+ * written with a boundary space (e.g. ' esso', 'vy ') then only matches at a real
+ * word edge — ' esso' won't hit inside 'espresso'. Every matcher must build its
+ * haystack here so that boundary trick stays uniform across the codebase.
+ */
+export function buildMatchHaystack(merchant?: string, description?: string): string {
+  return ` ${merchant ?? ''} ${description ?? ''} `.toLowerCase();
+}

--- a/src/lib/validators.test.ts
+++ b/src/lib/validators.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseLocaleNumber,
-  isPositiveNumber,
+  isNonNegativeNumber,
   isFiniteNumber,
   isValidYearMonth,
   isValidYearMonthDay,
@@ -30,15 +30,19 @@ describe('parseLocaleNumber', () => {
   });
 });
 
-describe('isPositiveNumber / isFiniteNumber', () => {
+describe('isNonNegativeNumber / isFiniteNumber', () => {
   it('accepts comma decimals', () => {
-    expect(isPositiveNumber('4,5')).toBe(true);
+    expect(isNonNegativeNumber('4,5')).toBe(true);
     expect(isFiniteNumber('-4,5')).toBe(true);
   });
 
-  it('rejects negatives for isPositiveNumber', () => {
-    expect(isPositiveNumber('-1')).toBe(false);
-    expect(isPositiveNumber('4,5kr')).toBe(false);
+  it('accepts 0 (name reflects that it allows non-negative, not strictly > 0)', () => {
+    expect(isNonNegativeNumber('0')).toBe(true);
+  });
+
+  it('rejects negatives for isNonNegativeNumber', () => {
+    expect(isNonNegativeNumber('-1')).toBe(false);
+    expect(isNonNegativeNumber('4,5kr')).toBe(false);
   });
 });
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -31,6 +31,11 @@ export function isOptionalYearMonth(s: string): boolean {
  * ("4,5" → 4.5). Returns NaN for anything that isn't a clean number — including
  * trailing garbage like "4,5kr", which `parseFloat` would silently truncate to
  * 4. Use this in every text-input save handler instead of `parseFloat`.
+ *
+ * Deliberately STRICTER than `coerceNumber` in sanitizePayload.ts: this rejects
+ * a thousands-space ("12 000" → NaN) so an ambiguous live keystroke surfaces as
+ * an error, whereas coerceNumber tolerates it when salvaging already-stored /
+ * imported blobs. Keep the two grammars distinct on purpose.
  */
 export function parseLocaleNumber(s: string): number {
   const cleaned = s.trim().replace(',', '.');
@@ -39,7 +44,8 @@ export function parseLocaleNumber(s: string): number {
   return parseFloat(cleaned);
 }
 
-export function isPositiveNumber(s: string): boolean {
+/** A finite number ≥ 0 (accepts 0; rejects negatives and garbage). */
+export function isNonNegativeNumber(s: string): boolean {
   const n = parseLocaleNumber(s);
   return !isNaN(n) && isFinite(n) && n >= 0;
 }

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -26,6 +26,7 @@ import { categoryMeta, isCategoryKey, CATEGORIES, type CategoryKey } from '../li
 import { suggestEnvelopeLinks, envelopeKeyForTx, type Envelope, type EnvelopeStatus } from '../lib/envelopes';
 import { sumLedgerSpent } from '../lib/spentTotals';
 import { formatSignedPct } from '../lib/format';
+import { incomeDiffPct } from '../lib/income';
 import { CHART } from '../lib/chartColors';
 import { CategoryBreakdown } from '../components/CategoryBreakdown';
 import { ProgressBar } from '../components/ui/ProgressBar';
@@ -142,6 +143,7 @@ const BudgetPage: React.FC = () => {
     dismissIncomeReminder,
     monthlyBudget,
     dailyBudget,
+    totalFixedExpenses,
     fixedExpenses,
     setFixedExpenses,
     debts,
@@ -169,7 +171,6 @@ const BudgetPage: React.FC = () => {
   const openModal = (config: ModalConfig) => setModal(config);
   const closeModal = () => setModal(null);
 
-  const totalFixedExpenses = fixedExpenses.reduce((sum, item) => sum + item.amount, 0);
   // Informational only — not folded into totalFixedExpenses (which drives budget
   // math); surfaces the monthly minimum debt service alongside fixed costs.
   const totalMonthlyDebtService = debts.reduce((sum, d) => sum + d.minPayment, 0);
@@ -435,7 +436,7 @@ const BudgetPage: React.FC = () => {
   const today = new Date();
   const isCurrentMonth = isSameMonth(currentMonth, today);
   const isPast = currentMonth < startOfMonth(today);
-  const incomeDiffPct = averageIncome > 0 ? ((effectiveIncome - averageIncome) / averageIncome) * 100 : 0;
+  const incomeDiff = incomeDiffPct(effectiveIncome, averageIncome);
   // Remind the user to set THIS month's income while it's still auto-calculated.
   // Only for the live month; dismissible, but the dismiss is keyed to the month
   // so it returns once a new month begins.
@@ -504,7 +505,7 @@ const BudgetPage: React.FC = () => {
           {t.budgetPage.heroTitlePre}<em className="font-serif italic" style={{ color: 'var(--brass)' }}>{t.budgetPage.heroTitleEm}</em>{t.budgetPage.heroTitlePost}
         </h1>
         <p className="mt-3 text-[15px] leading-[1.55] max-w-2xl" style={{ color: 'var(--text-2)' }}>
-          {`${t.budgetPage.incomeIntro}${formatCurrency(effectiveIncome)}${averageIncome > 0 && Object.keys(monthlyIncomes).length > 1 ? ` (${formatSignedPct(incomeDiffPct, 1, '')}${t.budgetPage.vsAvgSuffix}` : ''}${t.budgetPage.incomeOutro}`}
+          {`${t.budgetPage.incomeIntro}${formatCurrency(effectiveIncome)}${averageIncome > 0 && Object.keys(monthlyIncomes).length > 1 ? ` (${formatSignedPct(incomeDiff, 1, '')}${t.budgetPage.vsAvgSuffix}` : ''}${t.budgetPage.incomeOutro}`}
         </p>
       </header>
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -33,6 +33,7 @@ import { lastNMonthKeys } from '../lib/date';
 import { sumSavings } from '../lib/equity';
 import { sumDiscretionarySpent } from '../lib/spentTotals';
 import { formatSignedPct } from '../lib/format';
+import { incomeDiffPct } from '../lib/income';
 import { categoryMoM } from '../lib/categoryStats';
 import { isCategoryKey } from '../lib/categories';
 
@@ -112,7 +113,7 @@ const DashboardPage: React.FC = () => {
   const budgetUsedPct = Math.min(100, budgetUsedPctRaw);
   const spentPct = Math.min(100 - budgetUsedPct, spentPctRaw);
   const availablePct = Math.max(0, 100 - budgetUsedPct - spentPct);
-  const incomeDiffPct = averageIncome > 0 ? ((effectiveIncome - averageIncome) / averageIncome) * 100 : 0;
+  const incomeDiff = incomeDiffPct(effectiveIncome, averageIncome);
   const incomeDelta = prevMonthIncome > 0 ? ((effectiveIncome - prevMonthIncome) / prevMonthIncome) * 100 : null;
   // The chip compares the context's transfer-netted pair, not totalSpent —
   // totalSpent still counts a transfer's expense leg (see FinanceContext).
@@ -513,8 +514,8 @@ const DashboardPage: React.FC = () => {
             <div className="text-right">
               <div className="text-[24px] font-semibold tabular-nums">{formatCurrency(effectiveIncome)}</div>
               <div className="mt-1">
-                <DeltaChip tone={incomeDiffPct >= 0 ? 'positive' : 'negative'} size="sm">
-                  {formatSignedPct(incomeDiffPct)} vs avg
+                <DeltaChip tone={incomeDiff >= 0 ? 'positive' : 'negative'} size="sm">
+                  {formatSignedPct(incomeDiff)} vs avg
                 </DeltaChip>
               </div>
             </div>

--- a/src/pages/EmployerCostPage.tsx
+++ b/src/pages/EmployerCostPage.tsx
@@ -21,11 +21,14 @@ const EmployerCostPage: React.FC = () => {
   const ec = t.employerCost;
   const isNo = region === 'no';
 
-  // Salary auto-filled from the salary system, with manual override.
-  const derivedGross = useMemo(() => {
-    const today = currentMonthKey();
-    return calcActiveGrossAnnual(salaries, jobs, today);
-  }, [salaries, jobs]);
+  // Salary auto-filled from the salary system, with manual override. `today`
+  // lives in render scope so the value recomputes if the month rolls over during
+  // a long-lived session.
+  const today = currentMonthKey();
+  const derivedGross = useMemo(
+    () => calcActiveGrossAnnual(salaries, jobs, today),
+    [salaries, jobs, today],
+  );
   const [salaryOverride, setSalaryOverride] = useState<number | null>(null);
   const gross = salaryOverride ?? derivedGross;
   const isAuto = salaryOverride === null;

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -24,20 +24,23 @@ function formatAxisInt(val: number): string {
 const ForecastPage: React.FC = () => {
   const { t, totalEquity, salaries, jobs, loan, income, housingMode, homeowner, formatCurrency, region, customTaxRatePct, pension } = useFinance();
 
+  // Current month in render scope so the memos below recompute if the month
+  // rolls over during a long-lived session.
+  const today = currentMonthKey();
   // Find current salary (most recent effectiveDate <= today).
   const currentGross = useMemo(() => {
     // Fall back to the legacy monthly `income` annualized (matching
     // grossAnnualIncome elsewhere) rather than a fabricated magic number.
-    return salaryAt(currentMonthKey(), salaries)?.grossAnnual ?? income * 12;
-  }, [salaries, income]);
+    return salaryAt(today, salaries)?.grossAnnual ?? income * 12;
+  }, [salaries, income, today]);
 
   // Current job's on-call annual (for OTP base).
   const currentOnCall = useMemo(() => {
-    const latest = salaryAt(currentMonthKey(), salaries);
+    const latest = salaryAt(today, salaries);
     if (!latest) return 0;
     const job = jobs.find(j => j.id === latest.jobId);
     return job?.onCallAnnual ?? 0;
-  }, [salaries, jobs]);
+  }, [salaries, jobs, today]);
 
   // Retirement readiness: years to retirement + projected pension wealth.
   const retirement = useMemo(() => {

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -529,10 +529,10 @@ const LoanPage: React.FC = () => {
                   <div className="flex justify-between text-[11px] text-[var(--text-2)] mb-1.5">
                     <span>{lp.repaidOfOriginal}</span>
                     <span className="font-mono font-medium text-[var(--text-1)]">
-                      {homeownerStatus.equityPercent.toFixed(1)}%
+                      {homeownerStatus.originalLoanRepaidPercent.toFixed(1)}%
                     </span>
                   </div>
-                  <ProgressBar pct={homeownerStatus.equityPercent} color="var(--positive)" />
+                  <ProgressBar pct={homeownerStatus.originalLoanRepaidPercent} color="var(--positive)" />
                 </div>
               )}
             </div>

--- a/src/pages/PensionPage.tsx
+++ b/src/pages/PensionPage.tsx
@@ -37,11 +37,14 @@ const PensionPage: React.FC = () => {
     ? Math.max(0, pension.retirementAge - (currentYear - pension.birthYear))
     : 0;
 
-  // Pensionable income: latest salary + on-call.
-  const pensionableIncome = useMemo(() => {
-    const today = currentMonthKey();
-    return calcActiveGrossAnnual(salaries, jobs, today);
-  }, [salaries, jobs]);
+  // Pensionable income: latest salary + on-call. `today` lives in render scope
+  // (not inside the memo) so the value recomputes if the month rolls over during
+  // a long-lived session.
+  const today = currentMonthKey();
+  const pensionableIncome = useMemo(
+    () => calcActiveGrossAnnual(salaries, jobs, today),
+    [salaries, jobs, today],
+  );
 
   const otpAnnualContribution = pensionableIncome * (pension.otpEmployerPct + pension.otpEmployeePct) / 100;
   const ipsAnnualContribution = Math.min(pension.ipsAnnualContribution, IPS_MAX_DEDUCTION);

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -44,7 +44,7 @@ import { calcTaxByRegion } from '../lib/norwegianTax';
 import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from '../lib/date';
 import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH } from '../lib/salary';
 import { formatSignedPct } from '../lib/format';
-import { isValidYearMonth, isValidYearMonthDay, isOptionalYearMonth, isPositiveNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
+import { isValidYearMonth, isValidYearMonthDay, isOptionalYearMonth, isNonNegativeNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
@@ -427,7 +427,7 @@ const SalaryPage: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errInvalidEndDate });
           return;
         }
-        if (!isPositiveNumber(vals.contractedHoursPerWeek)) {
+        if (!isNonNegativeNumber(vals.contractedHoursPerWeek)) {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errHoursPositive });
           return;
         }
@@ -515,7 +515,7 @@ const SalaryPage: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errInvalidDateMonth });
           return;
         }
-        if (!isPositiveNumber(vals.grossAnnual)) {
+        if (!isNonNegativeNumber(vals.grossAnnual)) {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errSalaryPositive });
           return;
         }
@@ -576,7 +576,7 @@ const SalaryPage: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errInvalidDateDay });
           return;
         }
-        if (!isPositiveNumber(vals.amount)) {
+        if (!isNonNegativeNumber(vals.amount)) {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errAmountPositive });
           return;
         }
@@ -619,7 +619,7 @@ const SalaryPage: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errInvalidDateDay });
           return;
         }
-        if (!isPositiveNumber(vals.hours) || !isPositiveNumber(vals.amount)) {
+        if (!isNonNegativeNumber(vals.hours) || !isNonNegativeNumber(vals.amount)) {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errHoursAmountPositive });
           return;
         }
@@ -660,7 +660,7 @@ const SalaryPage: React.FC = () => {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errInvalidMonth });
           return;
         }
-        if (!isPositiveNumber(vals.actualHoursPerWeek)) {
+        if (!isNonNegativeNumber(vals.actualHoursPerWeek)) {
           setModal(prev => prev && { ...prev, error: t.salaryPage.errHoursPositiveShort });
           return;
         }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -99,6 +99,14 @@ export default function SettingsPage() {
   const [usdRateInput, setUsdRateInput] = useState(String(nokToUsd));
   const [customCodeInput, setCustomCodeInput] = useState(customCurrencyCode);
   const [customRateInput, setCustomRateInput] = useState(String(customCurrencyRate));
+  // Re-sync the editable drafts when the committed context values change from
+  // outside (a JSON import or demo toggle) — same pattern as RangeRow below.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setUsdRateInput(String(nokToUsd)); }, [nokToUsd]);
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setCustomCodeInput(customCurrencyCode); }, [customCurrencyCode]);
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setCustomRateInput(String(customCurrencyRate)); }, [customCurrencyRate]);
 
   // Import state
   const [importState, setImportState] = useState<ImportState>('idle');


### PR DESCRIPTION
## Why

Logic-cleanup pass implementing the dedup/hygiene items from IMPROVEMENTS.md §5.6
and §5.7. Removes copy-pasted logic that can silently drift, gives two misleading
symbols honest names, and fixes small runtime-staleness bugs. Behavior-preserving
except where noted. No UI/colour/component-extraction changes (owned by a separate PR).

## What

- **§5.6a** Extracted `buildMatchHaystack(merchant, description)` to `src/lib/text.ts`
  (word-boundary padding documented once) and reused it in `categorize.ts`,
  `envelopes.ts`, `labelRules.ts`. The single-string name haystack in
  `envelopes.ts` (`suggestCategoryForExpenseName`) has a different shape and was left.
- **§5.6c** `calcActiveGrossAnnual` now reuses `salaryAt`'s "latest salary <= month"
  selection per job. Common-path behavior identical; the only change is the degenerate
  same-job/same-effectiveDate tie (now last-in-array, consistent with `salaryAt` /
  ForecastPage), locked by a new `salary.test.ts` test.
- **§5.6e** BudgetPage reuses the context's exported `totalFixedExpenses` instead of
  recomputing it; the duplicated `incomeDiffPct` formula (BudgetPage + DashboardPage)
  is extracted to `src/lib/income.ts` and reused in both. Labels stay at the call site.
- **§5.7a** Renamed `isPositiveNumber` -> `isNonNegativeNumber` (it accepts 0) and
  updated all callers; behavior preserved. Documented the deliberate thousands-space
  divergence between `parseLocaleNumber` (strict input) and `coerceNumber` (lenient
  blob salvage) with a comment on each plus a test asserting the divergence.
- **§5.7b** Renamed `HomeownerStatus.equityPercent` -> `originalLoanRepaidPercent`
  (it is % of the original loan repaid, not home equity) across `calculations.ts`,
  its LoanPage consumer, and tests. The i18n label key `t.equityPercent` is UI copy
  and is left unchanged.
- **§5.7c** Added resync effects for the Settings currency draft inputs (USD rate,
  custom code, custom rate) mirroring the existing `RangeRow` pattern, so they follow
  a JSON import or demo toggle. All three currency inputs in that block are covered.
- **§5.7d** Hoisted `currentMonthKey()` out of the `useMemo` bodies and into the memo
  deps in PensionPage, ForecastPage, EmployerCostPage so "current month" is no longer
  pinned across a month boundary in a long-lived session.

Deferred (data-safety, runtime unchanged):
- **§5.6b** twin-dedup regex ambiguity. Added cross-reference comments in
  `src/lib/bankDedup.ts` and `server/bank.js` stating the two must stay byte-equivalent,
  and precisely documented the ambiguity. The regex is not changed: the prefixed vs bare
  id forms are structurally indistinguishable, so disambiguating risks resurrecting or
  double-counting real transactions. A documenting test locks current behavior. Tracked
  in BACKLOG.md ("Bank-id dedup regex ambiguity").
- **§5.7e** `deletedBankIds` unbounded growth. Pruning "ids no longer in the stored blob"
  would prune the whole set (deleted rows are absent from `dailyTransactions` by
  definition) and let the server reconcile resurrect them; no client-side signal proves
  a deleted id can never return from a future sync. Runtime unchanged; tracked in
  BACKLOG.md.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, `npm test` 391 passed (382 baseline + 9 new).
- `npm run build` (tsc + vite) succeeds.
- New/updated tests: `text.test.ts`, `income.test.ts`, `salary.test.ts` (tie-break),
  `validators.test.ts` (0 accepted + rename), `sanitizePayload.test.ts` (grammar
  divergence), `bankDedup.test.ts` (ambiguity), `calculations.test.ts` (rename).
- No Docker/browser smoke run: the UI-touching changes (Settings resync, memo deps,
  field/var renames) are behavior-preserving refactors covered by types + tests.
