### PR TITLE
refactor(ui): shared UI primitives + colour tokens

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -34,7 +34,7 @@ export default function ConfirmModal({
           <button
             onClick={onConfirm}
             className={`flex-1 py-2.5 rounded-[6px] text-[13px] font-semibold text-[var(--text)] transition-colors ${
-              danger ? 'bg-[var(--rust)] hover:bg-[#9c4632]' : 'bg-[var(--forest)] hover:bg-[var(--forest-dim)]'
+              danger ? 'bg-[var(--rust)] hover:bg-[var(--rust-dim)]' : 'bg-[var(--forest)] hover:bg-[var(--forest-dim)]'
             }`}
           >
             {confirmLabel}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,7 +50,7 @@ const Layout: React.FC = () => {
   const statusBg = isCurrentMonth
     ? 'var(--positive-bg)'
     : isPast
-      ? 'rgba(255,255,255,0.05)'
+      ? 'var(--surface-4)'
       : 'var(--violet-bg)';
   const statusLabel = isCurrentMonth
     ? t.viewingCurrent
@@ -160,7 +160,7 @@ const Layout: React.FC = () => {
           ) : hideTimeMarker ? null : (
             <div
               className="flex items-center gap-1.5 rounded-[6px] border px-3 h-9"
-              style={{ background: 'rgba(255,255,255,0.03)', borderColor: 'var(--border)' }}
+              style={{ background: 'var(--surface-2)', borderColor: 'var(--border)' }}
               title={t.asOfTodayHint}
             >
               <span

--- a/src/components/NetWorthHistoryModal.tsx
+++ b/src/components/NetWorthHistoryModal.tsx
@@ -102,7 +102,7 @@ export default function NetWorthHistoryModal({ series, formatCurrency, onClose }
                       onBlur={(e) => commit(p.monthKey, e.target.value)}
                       onKeyDown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
                       className="flex-1 min-w-0 h-9 px-3 rounded-[8px] text-[13px] font-mono outline-none border focus:ring-2 focus:ring-[var(--positive)]"
-                      style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
+                      style={{ background: 'var(--surface-3)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
                     />
                     <ProvenanceBadge kind={p.estimated ? 'estimate' : 'custom'} />
                     <button

--- a/src/components/ui/DeltaChip.tsx
+++ b/src/components/ui/DeltaChip.tsx
@@ -19,7 +19,7 @@ const toneStyle: Record<Tone, { bg: string; color: string }> = {
   accent: { bg: 'var(--accent-bg)', color: 'var(--accent)' },
   violet: { bg: 'var(--violet-bg)', color: 'var(--violet)' },
   pink: { bg: 'var(--pink-bg)', color: 'var(--pink)' },
-  muted: { bg: 'rgba(255,255,255,0.06)', color: 'var(--text-2)' },
+  muted: { bg: 'var(--surface-5)', color: 'var(--text-2)' },
 };
 
 export function DeltaChip({

--- a/src/components/ui/NumberRow.tsx
+++ b/src/components/ui/NumberRow.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { parseLocaleNumber } from '../../lib/validators';
+
+/**
+ * Labelled numeric input with a locally-buffered draft that re-syncs when the
+ * committed value changes from outside. Optional provenance `badge` next to the
+ * label. Shared by the Pension and Employer-cost pages.
+ */
+export function NumberRow({
+  label,
+  value,
+  onCommit,
+  suffix,
+  badge,
+}: {
+  label: string;
+  value: number;
+  onCommit: (v: number) => void;
+  suffix?: string;
+  badge?: ReactNode;
+}) {
+  const [draft, setDraft] = useState(value.toString());
+  // Re-sync the editable draft when the committed value changes from outside.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setDraft(value.toString()); }, [value]);
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-2 gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>{label}</label>
+          {badge}
+        </div>
+        {suffix && <span className="text-[11px] font-mono" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
+      </div>
+      <input
+        type="number"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => { const n = parseLocaleNumber(draft); onCommit(Number.isFinite(n) ? n : 0); }}
+        className="w-full h-10 px-3 rounded-[8px] text-[14px] font-mono outline-none border"
+        style={{ background: 'var(--surface-3)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/ProvenanceBadge.tsx
+++ b/src/components/ui/ProvenanceBadge.tsx
@@ -4,7 +4,7 @@ import type { Provenance } from '../../lib/provenance';
 const toneFor: Record<Provenance, { bg: string; color: string }> = {
   default: { bg: 'var(--warning-bg)', color: 'var(--warning)' },
   custom: { bg: 'var(--positive-bg)', color: 'var(--positive)' },
-  estimate: { bg: 'rgba(255,255,255,0.06)', color: 'var(--text-2)' },
+  estimate: { bg: 'var(--surface-5)', color: 'var(--text-2)' },
 };
 
 interface ProvenanceBadgeProps {

--- a/src/components/ui/SliderRow.tsx
+++ b/src/components/ui/SliderRow.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from 'react';
+
+/**
+ * Labelled range slider showing the live value + suffix, with an optional
+ * provenance `badge` next to the label. Shared by the Pension and Employer-cost
+ * pages.
+ */
+export function SliderRow({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  suffix,
+  badge,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  min: number;
+  max: number;
+  step: number;
+  suffix: string;
+  badge?: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-2 gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>{label}</label>
+          {badge}
+        </div>
+        <span className="text-[18px] font-semibold tabular-nums">
+          {value}
+          {suffix && <span className="text-[12px] ml-1" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full"
+        style={{ accentColor: 'var(--accent)' }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/SummaryTile.tsx
+++ b/src/components/ui/SummaryTile.tsx
@@ -1,0 +1,29 @@
+import { Card } from './Card';
+
+/**
+ * Headline metric tile: uppercase label, large mono value, optional sub-line.
+ * Shared by the Pension and Employer-cost pages (identical hand-rolled copies
+ * before extraction). The Salary/Forecast/Loan pages keep bespoke variants
+ * with different padding, layout, or extra slots.
+ */
+export function SummaryTile({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <Card padding="md">
+      <div className="text-[11px] font-medium uppercase tracking-[0.1em]" style={{ color: 'var(--text-2)' }}>{label}</div>
+      <div className="text-[14px] md:text-[24px] leading-tight [overflow-wrap:anywhere] font-semibold font-mono tabular-nums mt-1.5" style={{ color: color ?? 'var(--text-1)' }}>
+        {value}
+      </div>
+      {sub && <div className="text-[11px] font-mono mt-1" style={{ color: 'var(--text-3)' }}>{sub}</div>}
+    </Card>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,3 +6,6 @@ export { Button } from './Button';
 export { ProvenanceBadge } from './ProvenanceBadge';
 export { ModalShell } from './ModalShell';
 export { ProgressBar } from './ProgressBar';
+export { SummaryTile } from './SummaryTile';
+export { NumberRow } from './NumberRow';
+export { SliderRow } from './SliderRow';

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,7 @@
   --brass: #C9A24A;         /* headline totals, active nav, warnings — never decorative */
   --brass-dim: #8C7A45;
   --rust: #B5533A;          /* debt, negative values, risk */
+  --rust-dim: #9c4632;      /* darker rust for danger-button hover (matches --forest-dim pattern) */
 
   /* ── Legacy aliases (map old names → old-money palette) ── */
   --bg-page: var(--bg);
@@ -62,6 +63,15 @@
   --accent-bg: color-mix(in srgb, var(--accent) 14%, transparent);
   --violet-bg: color-mix(in srgb, var(--violet) 14%, transparent);
   --pink-bg: color-mix(in srgb, var(--pink) 14%, transparent);
+
+  /* Neutral white-tint surface overlays (raised rows, inputs, hover). Numbered
+     by increasing opacity; kept as tokens so the levels don't drift. Dark-only
+     theme, so a single white-alpha value per level is correct. */
+  --surface-1: rgba(255,255,255,0.025);
+  --surface-2: rgba(255,255,255,0.03);
+  --surface-3: rgba(255,255,255,0.04);
+  --surface-4: rgba(255,255,255,0.05);
+  --surface-5: rgba(255,255,255,0.06);
 
   /* Chart roles — max ~4 hues + neutral "Annet"; group the rest, never add a 5th color. */
   --chart-1: var(--forest);

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -16,6 +16,7 @@ export const CHART = {
   rule: '#262A20',         // --rule / --border
   grid: 'rgba(236,231,216,0.06)',
   track: 'rgba(236,231,216,0.05)',
+  surface2: 'rgba(255,255,255,0.03)', // --surface-2 (tooltip cursor fill; SVG can't resolve var())
 } as const;
 
 // Categorical series colour order (matches the 4 category hues + accents).

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatSignedPct } from './format';
+import { formatSignedPct, formatAxisInt } from './format';
 
 describe('formatSignedPct', () => {
   it('prefixes + for zero and positive values, nothing extra for negative', () => {
@@ -19,5 +19,27 @@ describe('formatSignedPct', () => {
     expect(formatSignedPct(undefined)).toBe('—');
     expect(formatSignedPct(NaN)).toBe('—');
     expect(formatSignedPct(Infinity)).toBe('—');
+  });
+});
+
+describe('formatAxisInt', () => {
+  it('renders millions with one decimal and an M suffix', () => {
+    expect(formatAxisInt(1_500_000)).toBe('1.5M');
+    expect(formatAxisInt(1_000_000)).toBe('1.0M');
+    expect(formatAxisInt(-2_300_000)).toBe('-2.3M');
+  });
+
+  it('renders thousands as a rounded integer with a k suffix', () => {
+    expect(formatAxisInt(12_000)).toBe('12k');
+    expect(formatAxisInt(1_000)).toBe('1k');
+    expect(formatAxisInt(1_499)).toBe('1k');
+    expect(formatAxisInt(1_500)).toBe('2k');
+    expect(formatAxisInt(-12_000)).toBe('-12k');
+  });
+
+  it('renders values below 1000 as the raw integer string', () => {
+    expect(formatAxisInt(0)).toBe('0');
+    expect(formatAxisInt(999)).toBe('999');
+    expect(formatAxisInt(-500)).toBe('-500');
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -7,3 +7,14 @@ export function formatSignedPct(v: number | null | undefined, digits = 1, unit =
   if (v == null || !Number.isFinite(v)) return '—';
   return `${v >= 0 ? '+' : ''}${v.toFixed(digits)}${unit}`;
 }
+
+/**
+ * Compact axis-tick formatter for chart Y axes: 1_500_000 → "1.5M",
+ * 12_000 → "12k", below 1k the raw integer. One definition so every chart's
+ * tick labels stay consistent (was copy-pasted in four page components).
+ */
+export function formatAxisInt(val: number): string {
+  if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(val) >= 1_000) return `${Math.round(val / 1_000)}k`;
+  return val.toString();
+}

--- a/src/pages/AssetPage.tsx
+++ b/src/pages/AssetPage.tsx
@@ -37,6 +37,7 @@ import { computeEquityBreakdown, sumSavings } from '../lib/equity';
 import { calcNetWorthProjectionByBucket, calcHouseEquityByYear, calcMortgageBalanceByYear } from '../lib/calculations';
 import { calcDebtBalanceByYear, sumDebtByType } from '../lib/debt';
 import { parseLocaleNumber } from '../lib/validators';
+import { formatAxisInt } from '../lib/format';
 
 interface ModalConfig {
   title: string;
@@ -172,12 +173,6 @@ const AssetPage: React.FC = () => {
     ),
     [netInvestment, netCrypto, cashStart, houseEquity, annualSavings, growthReturnRate, cryptoGrowthRate, cashGrowthRate, houseGrowthRate, houseByYear, debtByYear]
   );
-
-  const formatAxisValue = (val: number) => {
-    if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
-    if (Math.abs(val) >= 1_000) return `${Math.round(val / 1_000)}k`;
-    return val.toString();
-  };
 
   const editRate = (label: string, current: number, onCommit: (v: number) => void) => {
     openModal({
@@ -570,7 +565,7 @@ const AssetPage: React.FC = () => {
               </defs>
               <CartesianGrid {...GRID_PROPS} />
               <XAxis dataKey="year" {...AXIS_PROPS} />
-              <YAxis tickFormatter={formatAxisValue} {...AXIS_PROPS_Y} width={52} />
+              <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip content={<ChartTooltip />} />
               <Area type="monotone" dataKey="house" stackId="1" name={t.bucketHouse} stroke={CHART.teal} fill="url(#houseGrad)" />
               <Area type="monotone" dataKey="cash" stackId="1" name={t.bucketCash} stroke={CHART.slate} fill="url(#cashGrad)" />

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -474,7 +474,7 @@ const BudgetPage: React.FC = () => {
           <span
             className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-[4px] text-[10px] font-semibold uppercase tracking-[0.1em]"
             style={{
-              background: isCurrentMonth ? 'var(--positive-bg)' : isPast ? 'rgba(255,255,255,0.05)' : 'var(--violet-bg)',
+              background: isCurrentMonth ? 'var(--positive-bg)' : isPast ? 'var(--surface-4)' : 'var(--violet-bg)',
               color: isCurrentMonth ? 'var(--positive)' : isPast ? 'var(--text-3)' : 'var(--violet)',
             }}
           >

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -400,7 +400,7 @@ const DashboardPage: React.FC = () => {
           </div>
 
           {/* Hero chart — clean 12-month actual net-equity trend */}
-          <div className="mt-6 rounded-[8px] border p-4" style={{ background: 'rgba(255,255,255,0.025)', borderColor: 'var(--border)' }}>
+          <div className="mt-6 rounded-[8px] border p-4" style={{ background: 'var(--surface-1)', borderColor: 'var(--border)' }}>
             <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.14em] mb-2" style={{ color: 'var(--text-3)' }}>
               <div className="flex items-center gap-2">
                 <span>{t.dashboardPage.netEquityLast12}</span>
@@ -469,7 +469,7 @@ const DashboardPage: React.FC = () => {
               </span>
             )}
           </div>
-          <div className="mt-4 rounded-[8px] border p-3" style={{ background: 'rgba(255,255,255,0.025)', borderColor: 'var(--border)' }}>
+          <div className="mt-4 rounded-[8px] border p-3" style={{ background: 'var(--surface-1)', borderColor: 'var(--border)' }}>
             <div className="flex items-center justify-between mb-2">
               <div className="flex gap-3 text-[10px] uppercase tracking-[0.1em]" style={{ color: 'var(--text-3)' }}>
                 <span><span className="inline-block w-2 h-0.5 mr-1.5 align-middle" style={{ background: 'var(--accent)' }} /> {t.dashboardPage.actual}</span>
@@ -886,7 +886,7 @@ const DashboardPage: React.FC = () => {
                 return (
                   <div
                     key={tx.id}
-                    className="px-6 py-3.5 grid items-center gap-3 border-b last:border-0 transition-colors hover:bg-[rgba(255,255,255,0.025)]"
+                    className="px-6 py-3.5 grid items-center gap-3 border-b last:border-0 transition-colors hover:bg-[var(--surface-1)]"
                     style={{
                       gridTemplateColumns: '44px 1fr auto auto',
                       borderColor: 'var(--border)',

--- a/src/pages/EmployerCostPage.tsx
+++ b/src/pages/EmployerCostPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Receipt, Layers, HandCoins } from 'lucide-react';
 import { useFinance, calcActiveGrossAnnual } from '../context/FinanceContext';
 import { calcEmployerCost, calcBillingRate, DEFAULT_EMPLOYER_COST_CONFIG, DEFAULT_BILLING_CONFIG } from '../lib/employerCost';
@@ -6,6 +6,9 @@ import { Card } from '../components/ui/Card';
 import { SectionLabel } from '../components/ui/SectionLabel';
 import { RestoreDefaultsButton } from '../components/ui/RestoreDefaultsButton';
 import { ProvenanceBadge } from '../components/ui/ProvenanceBadge';
+import { SummaryTile } from '../components/ui/SummaryTile';
+import { NumberRow } from '../components/ui/NumberRow';
+import { SliderRow } from '../components/ui/SliderRow';
 import { provenanceOf } from '../lib/provenance';
 import { currentMonthKey } from '../lib/date';
 import { parseLocaleNumber } from '../lib/validators';
@@ -98,7 +101,7 @@ const EmployerCostPage: React.FC = () => {
                 <span
                   className="text-[10px] font-medium px-1.5 py-0.5 rounded"
                   style={{
-                    background: isAuto ? 'var(--accent-bg)' : 'rgba(255,255,255,0.06)',
+                    background: isAuto ? 'var(--accent-bg)' : 'var(--surface-5)',
                     color: isAuto ? 'var(--accent)' : 'var(--text-3)',
                   }}
                 >
@@ -113,7 +116,7 @@ const EmployerCostPage: React.FC = () => {
                   setSalaryOverride(Number.isFinite(n) ? n : 0);
                 }}
                 className="w-full h-10 px-3 rounded-[8px] text-[14px] font-mono outline-none border"
-                style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
+                style={{ background: 'var(--surface-3)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
               />
               {!isAuto && (
                 <button
@@ -134,7 +137,7 @@ const EmployerCostPage: React.FC = () => {
             </div>
             <p className="text-[11px]" style={{ color: 'var(--text-3)' }}>{ec.overheadHint}</p>
 
-            <div className="flex items-baseline justify-between rounded-[8px] px-3 py-2.5" style={{ background: 'rgba(255,255,255,0.03)' }}>
+            <div className="flex items-baseline justify-between rounded-[8px] px-3 py-2.5" style={{ background: 'var(--surface-2)' }}>
               <div>
                 <div className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>{pensionLabel}</div>
                 <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-3)' }}>{ec.employerPensionHint}</div>
@@ -191,7 +194,7 @@ const EmployerCostPage: React.FC = () => {
                 updateBillingConfig('billableHoursOverride', Number.isFinite(n) && n > 0 ? n : null);
               }}
               className="w-full h-10 px-3 rounded-[8px] text-[14px] font-mono outline-none border"
-              style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
+              style={{ background: 'var(--surface-3)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
             />
           </div>
           <SliderRow label={ec.targetMargin} value={billingConfig.targetMarginPct} onChange={(v) => updateBillingConfig('targetMarginPct', v)} min={0} max={95} step={1} suffix="%" badge={<ProvenanceBadge kind={provenanceOf(billingConfig.targetMarginPct, DEFAULT_BILLING_CONFIG.targetMarginPct)} />} />
@@ -222,21 +225,9 @@ const EmployerCostPage: React.FC = () => {
 
 // ─── Helpers ──────────────────────────────────────────────────────────
 
-function SummaryTile({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
-  return (
-    <Card padding="md">
-      <div className="text-[11px] font-medium uppercase tracking-[0.1em]" style={{ color: 'var(--text-2)' }}>{label}</div>
-      <div className="text-[14px] md:text-[24px] leading-tight [overflow-wrap:anywhere] font-semibold font-mono tabular-nums mt-1.5" style={{ color: color ?? 'var(--text-1)' }}>
-        {value}
-      </div>
-      {sub && <div className="text-[11px] font-mono mt-1" style={{ color: 'var(--text-3)' }}>{sub}</div>}
-    </Card>
-  );
-}
-
 function StatBlock({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
   return (
-    <div className="rounded-[8px] px-3 py-2.5" style={{ background: 'rgba(255,255,255,0.03)' }}>
+    <div className="rounded-[8px] px-3 py-2.5" style={{ background: 'var(--surface-2)' }}>
       <div className="text-[10px] font-medium uppercase tracking-[0.1em]" style={{ color: 'var(--text-3)' }}>{label}</div>
       <div className="text-[16px] md:text-[18px] leading-tight font-semibold font-mono tabular-nums mt-1 [overflow-wrap:anywhere]" style={{ color: color ?? 'var(--text-1)' }}>
         {value}
@@ -259,59 +250,6 @@ function BreakdownRow({ label, value, sub, muted, emphasis }: { label: string; v
       >
         {value}
       </span>
-    </div>
-  );
-}
-
-function NumberRow({ label, value, onCommit, suffix, badge }: { label: string; value: number; onCommit: (v: number) => void; suffix?: string; badge?: React.ReactNode }) {
-  const [draft, setDraft] = useState(value.toString());
-  // Re-sync the editable draft when the committed value changes from outside.
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => { setDraft(value.toString()); }, [value]);
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-2 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>{label}</label>
-          {badge}
-        </div>
-        {suffix && <span className="text-[11px] font-mono" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
-      </div>
-      <input
-        type="number"
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => { const n = parseLocaleNumber(draft); onCommit(Number.isFinite(n) ? n : 0); }}
-        className="w-full h-10 px-3 rounded-[8px] text-[14px] font-mono outline-none border"
-        style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
-      />
-    </div>
-  );
-}
-
-function SliderRow({ label, value, onChange, min, max, step, suffix, badge }: { label: string; value: number; onChange: (v: number) => void; min: number; max: number; step: number; suffix: string; badge?: React.ReactNode }) {
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-2 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>{label}</label>
-          {badge}
-        </div>
-        <span className="text-[18px] font-semibold tabular-nums">
-          {value}
-          {suffix && <span className="text-[12px] ml-1" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
-        </span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full"
-        style={{ accentColor: 'var(--accent)' }}
-      />
     </div>
   );
 }

--- a/src/pages/ForecastPage.tsx
+++ b/src/pages/ForecastPage.tsx
@@ -11,15 +11,10 @@ import { calcMonthlyPayment } from '../lib/calculations';
 import { pensionFutureValue } from '../lib/pension';
 import { currentMonthKey } from '../lib/date';
 import { salaryAt } from '../lib/salary';
+import { formatAxisInt } from '../lib/format';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
 const sectionLabel = 'text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--text-2)]';
-
-function formatAxisInt(val: number): string {
-  if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(val) >= 1_000) return `${Math.round(val / 1_000)}k`;
-  return val.toString();
-}
 
 const ForecastPage: React.FC = () => {
   const { t, totalEquity, salaries, jobs, loan, income, housingMode, homeowner, formatCurrency, region, customTaxRatePct, pension } = useFinance();

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -175,7 +175,7 @@ const LoanPage: React.FC = () => {
     <span
       className="text-[9px] font-semibold px-1.5 py-0.5 rounded uppercase tracking-wide"
       style={{
-        background: auto ? 'var(--accent-bg)' : 'rgba(255,255,255,0.06)',
+        background: auto ? 'var(--accent-bg)' : 'var(--surface-5)',
         color: auto ? 'var(--accent)' : 'var(--text-3)',
       }}
     >
@@ -294,7 +294,7 @@ const LoanPage: React.FC = () => {
       {/* Mode selector — pill segmented control */}
       <div
         className="inline-flex p-1 rounded-[8px] border flex-wrap gap-1"
-        style={{ background: 'rgba(255,255,255,0.03)', borderColor: 'var(--border)' }}
+        style={{ background: 'var(--surface-2)', borderColor: 'var(--border)' }}
         role="radiogroup"
       >
         {modeOptions.map(({ mode, label, icon }) => {

--- a/src/pages/PensionPage.tsx
+++ b/src/pages/PensionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import {
   Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis,
 } from 'recharts';
@@ -9,20 +9,17 @@ import { Card } from '../components/ui/Card';
 import { SectionLabel } from '../components/ui/SectionLabel';
 import { RestoreDefaultsButton } from '../components/ui/RestoreDefaultsButton';
 import { ProvenanceBadge } from '../components/ui/ProvenanceBadge';
+import { SummaryTile } from '../components/ui/SummaryTile';
+import { NumberRow } from '../components/ui/NumberRow';
+import { SliderRow } from '../components/ui/SliderRow';
 import { provenanceOf } from '../lib/provenance';
-import { parseLocaleNumber } from '../lib/validators';
 import { projectPensionWealth } from '../lib/pension';
 import { currentMonthKey } from '../lib/date';
+import { formatAxisInt } from '../lib/format';
 import BalanceHistoryBar from '../components/BalanceHistoryBar';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import ChartTooltip from '../components/ChartTooltip';
 import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors';
-
-function formatAxisInt(val: number): string {
-  if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(val) >= 1_000) return `${Math.round(val / 1_000)}k`;
-  return val.toString();
-}
 
 const PensionPage: React.FC = () => {
   const { t, pension: livePension, updatePension, salaries, jobs, formatCurrency, restorePensionAssumptionDefaults, region, customTaxRatePct } = useFinance();
@@ -245,115 +242,6 @@ const PensionPage: React.FC = () => {
     </>
   );
 };
-
-// ─── Helpers ──────────────────────────────────────────────────────────
-
-function SummaryTile({
-  label,
-  value,
-  sub,
-  color,
-}: {
-  label: string;
-  value: string;
-  sub?: string;
-  color?: string;
-}) {
-  return (
-    <Card padding="md">
-      <div className="text-[11px] font-medium uppercase tracking-[0.1em]" style={{ color: 'var(--text-2)' }}>{label}</div>
-      <div className="text-[14px] md:text-[24px] leading-tight [overflow-wrap:anywhere] font-semibold font-mono tabular-nums mt-1.5" style={{ color: color ?? 'var(--text-1)' }}>
-        {value}
-      </div>
-      {sub && <div className="text-[11px] font-mono mt-1" style={{ color: 'var(--text-3)' }}>{sub}</div>}
-    </Card>
-  );
-}
-
-function NumberRow({
-  label,
-  value,
-  onCommit,
-  suffix,
-}: {
-  label: string;
-  value: number;
-  onCommit: (v: number) => void;
-  suffix?: string;
-}) {
-  const [draft, setDraft] = useState(value.toString());
-  // Re-sync the editable draft when the committed value changes from outside.
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => { setDraft(value.toString()); }, [value]);
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-2">
-        <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>
-          {label}
-        </label>
-        {suffix && <span className="text-[11px] font-mono" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
-      </div>
-      <input
-        type="number"
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onBlur={() => {
-          const n = parseLocaleNumber(draft);
-          onCommit(Number.isFinite(n) ? n : 0);
-        }}
-        className="w-full h-10 px-3 rounded-[8px] text-[14px] font-mono outline-none border"
-        style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)', color: 'var(--text-1)' }}
-      />
-    </div>
-  );
-}
-
-function SliderRow({
-  label,
-  value,
-  onChange,
-  min,
-  max,
-  step,
-  suffix,
-  badge,
-}: {
-  label: string;
-  value: number;
-  onChange: (v: number) => void;
-  min: number;
-  max: number;
-  step: number;
-  suffix: string;
-  badge?: React.ReactNode;
-}) {
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-2 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <label className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--text-3)' }}>
-            {label}
-          </label>
-          {badge}
-        </div>
-        <span className="text-[18px] font-semibold tabular-nums">
-          {value}
-          {suffix && <span className="text-[12px] ml-1" style={{ color: 'var(--text-3)' }}>{suffix}</span>}
-        </span>
-      </div>
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full"
-        style={{ accentColor: 'var(--accent)' }}
-      />
-    </div>
-  );
-}
 
 export default PensionPage;
 

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -43,7 +43,7 @@ import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors'
 import { calcTaxByRegion } from '../lib/norwegianTax';
 import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from '../lib/date';
 import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH } from '../lib/salary';
-import { formatSignedPct } from '../lib/format';
+import { formatSignedPct, formatAxisInt } from '../lib/format';
 import { isValidYearMonth, isValidYearMonthDay, isOptionalYearMonth, isNonNegativeNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 
 const card = 'bg-[var(--bg-card)] rounded-[8px] border border-[var(--border)]';
@@ -690,12 +690,6 @@ const SalaryPage: React.FC = () => {
 
   // ── Render ─────────────────────────────────────────────────────
 
-  const formatAxisInt = (val: number) => {
-    if (Math.abs(val) >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
-    if (Math.abs(val) >= 1_000) return `${Math.round(val / 1_000)}k`;
-    return val.toString();
-  };
-
   // Clamp to the salary in effect *today* — the last entry may be a
   // future-dated raise, and the headline (`current`) is already clamped.
   const activeSalary = salaryAt(currentMonthKey, sortedSalaries);
@@ -948,7 +942,7 @@ const SalaryPage: React.FC = () => {
               <YAxis tickFormatter={(v) => `${v}%`} {...AXIS_PROPS_Y} width={44} />
               <Tooltip
                 content={<ChartTooltip valueFormatter={(v) => `${v.toFixed(1)}%`} />}
-                cursor={{ fill: 'rgba(255,255,255,0.03)' }}
+                cursor={{ fill: CHART.surface2 }}
               />
               <ReferenceLine y={0} stroke="var(--text-3)" strokeWidth={1} />
               <Bar dataKey="salaryPct" name={t.salaryPage.salaryIncrease} fill="var(--accent)" radius={[4, 4, 0, 0]}>
@@ -1044,7 +1038,7 @@ const SalaryPage: React.FC = () => {
               <YAxis tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={52} />
               <Tooltip
                 content={<ChartTooltip />}
-                cursor={{ fill: 'rgba(255,255,255,0.03)' }}
+                cursor={{ fill: CHART.surface2 }}
               />
               <Bar dataKey="base" stackId="a" name={t.salaryPage.baseSalary} fill="url(#compBaseGradient)" />
               <Bar dataKey="onCall" stackId="a" name={t.salary.onCallLabel} fill="url(#compOnCallGradient)" />
@@ -1084,7 +1078,7 @@ const SalaryPage: React.FC = () => {
               <YAxis yAxisId="left" tickFormatter={(v) => `${v}t`} {...AXIS_PROPS_Y} width={40} />
               <YAxis yAxisId="right" orientation="right" tickFormatter={formatAxisInt} {...AXIS_PROPS_Y} width={56} />
               <Tooltip
-                cursor={{ fill: 'rgba(255,255,255,0.03)' }}
+                cursor={{ fill: CHART.surface2 }}
                 content={<ChartTooltip valueFormatter={(v, e) => e?.dataKey === 'hoursPerWeek' ? `${v.toFixed(1)} ${t.common.hoursPerWeekUnit}` : formatCurrency(v)} />}
               />
               <Bar yAxisId="left" dataKey="hoursPerWeek" name={t.salaryPage.hoursPerWk} fill="url(#hoursGradient)" radius={[6, 6, 0, 0]}>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -230,7 +230,7 @@ export default function SettingsPage() {
           {/* Segmented control */}
           <div
             className="mt-5 inline-flex p-1 rounded-[8px] border"
-            style={{ background: 'rgba(255,255,255,0.04)', borderColor: 'var(--border)' }}
+            style={{ background: 'var(--surface-3)', borderColor: 'var(--border)' }}
             role="radiogroup"
             aria-label={t.settings.currency}
           >
@@ -267,7 +267,7 @@ export default function SettingsPage() {
                   onChange={e => setUsdRateInput(e.target.value)}
                   className="flex-1 h-10 px-3 rounded-[8px] text-[13px] font-mono outline-none border"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
+                    background: 'var(--surface-3)',
                     borderColor: 'var(--border)',
                     color: 'var(--text-1)',
                   }}
@@ -305,7 +305,7 @@ export default function SettingsPage() {
                   onChange={e => setCustomCodeInput(e.target.value.toUpperCase())}
                   className="w-20 h-10 px-3 rounded-[8px] text-[13px] font-mono uppercase outline-none border"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
+                    background: 'var(--surface-3)',
                     borderColor: 'var(--border)',
                     color: 'var(--text-1)',
                   }}
@@ -319,7 +319,7 @@ export default function SettingsPage() {
                   onChange={e => setCustomRateInput(e.target.value)}
                   className="flex-1 h-10 px-3 rounded-[8px] text-[13px] font-mono outline-none border"
                   style={{
-                    background: 'rgba(255,255,255,0.04)',
+                    background: 'var(--surface-3)',
                     borderColor: 'var(--border)',
                     color: 'var(--text-1)',
                   }}
@@ -605,7 +605,7 @@ export default function SettingsPage() {
             {/* Export */}
             <div
               className="rounded-[8px] border p-5 flex flex-col"
-              style={{ background: 'rgba(255,255,255,0.025)', borderColor: 'var(--border)' }}
+              style={{ background: 'var(--surface-1)', borderColor: 'var(--border)' }}
             >
               <div className="flex items-start gap-3">
                 <div
@@ -646,7 +646,7 @@ export default function SettingsPage() {
             {/* Import */}
             <div
               className="rounded-[8px] border p-5 flex flex-col"
-              style={{ background: 'rgba(255,255,255,0.025)', borderColor: 'var(--border)' }}
+              style={{ background: 'var(--surface-1)', borderColor: 'var(--border)' }}
             >
               <div className="flex items-start gap-3">
                 <div
@@ -882,7 +882,7 @@ function LangCard({
       aria-pressed={active}
       className="flex items-center gap-3 px-4 py-3 rounded-[8px] border transition-colors text-left"
       style={{
-        background: active ? 'var(--accent-bg)' : 'rgba(255,255,255,0.04)',
+        background: active ? 'var(--accent-bg)' : 'var(--surface-3)',
         borderColor: active ? 'color-mix(in srgb, var(--accent) 50%, transparent)' : 'var(--border)',
       }}
     >
@@ -953,7 +953,7 @@ function RangeRow({
             onChange={e => setDraft(e.target.value)}
             onBlur={commitDraft}
             onKeyDown={e => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
-            className="w-20 text-right text-[18px] font-semibold tabular-nums bg-transparent outline-none rounded px-1 hover:bg-[rgba(255,255,255,0.04)] focus:bg-[rgba(255,255,255,0.04)] transition-colors"
+            className="w-20 text-right text-[18px] font-semibold tabular-nums bg-transparent outline-none rounded px-1 hover:bg-[var(--surface-3)] focus:bg-[var(--surface-3)] transition-colors"
             style={{ color: 'var(--text-1)' }}
           />
           <span className="text-[12px]" style={{ color: 'var(--text-3)' }}>{suffix}</span>


### PR DESCRIPTION
## Why

`SummaryTile`/`NumberRow`/`SliderRow` were hand-rolled and copy-pasted across pages, `formatAxisInt` was defined four times, and several colours were raw literals with no design token (a bespoke `#9c4632` danger-hover and recurring `rgba(255,255,255,0.0x)` surface backgrounds). This is IMPROVEMENTS.md §5.6d and the §5.5 residual.

## What

Pure refactor / token substitution, zero intended visual change.

§5.6d - shared primitives:
- New `src/components/ui/{SummaryTile,NumberRow,SliderRow}.tsx`; Pension and Employer-cost pages rewired to them. `SummaryTile` was byte-identical across those two. `NumberRow` adopts the badge-capable superset markup (Pension's rows gain a layout-inert wrapper div; no visual change). `SliderRow` was already identical.
- Forecast (now/then two-value tile), Salary (chip slot, `p-4` padding) and Loan (compact accent tile) `SummaryTile` variants stay bespoke - their layout/padding differ enough that folding them in would shift spacing or bloat the shared API.
- `formatAxisInt` moved to `src/lib/format.ts` with unit tests; reused in Pension, Forecast, Salary and Asset (replacing four copies).

§5.5 - colour tokens (each new token's value is byte-identical to the literal it replaces):
- `--rust-dim: #9c4632` for the ConfirmModal danger-button hover (mirrors `--forest-dim`/`--brass-dim`).
- `--surface-1..5` white-tint overlays at `0.025/0.03/0.04/0.05/0.06`, replacing the recurring `rgba(255,255,255,0.0x)` surface backgrounds across Layout, NetWorthHistoryModal, DeltaChip, ProvenanceBadge, Budget, Dashboard, Loan, Settings, Employer-cost and the shared NumberRow input.
- `CHART.surface2` in `chartColors.ts` mirrors `--surface-2` for the Recharts tooltip cursor fills, where SVG attributes can't resolve `var()`.

The app is dark-only (single `:root` in `index.css`; no light/`[data-theme]`/`prefers-color-scheme` block), so one value per token is correct.

## Verification

`npx tsc -b && npm run lint && npm test` all pass (385 tests, including the new `formatAxisInt` cases). `npm run build` (Vite production build) succeeds. Call sites are unchanged and the extracted components carry the originals' class strings verbatim.

No browser smoke was run. Because every change is an exact-value token substitution or a markup-preserving extraction, a lightweight browser smoke of the affected pages is recommended before merge (mind the service-worker cache gotcha).

## Notes

Independent of #19 and #20; branched off clean `main`. Those PRs touch `SettingsPage.tsx` and `EmployerCostPage.tsx` in different regions, so a trivial rebase on those two files may be needed after #19 merges.