### PR TITLE
docs: close out the maths/value audit (IMPROVEMENTS.md)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,405 @@
+# Feature & quality-of-life ideas (2026-07-09)
+
+Candidate improvements collected during two full code sweeps: a first pass over the pages,
+components and context focused on daily-use friction, and a second pass with three deeper
+lenses (finance-domain gaps grounded in what `src/lib/` already computes, self-hosting and
+operations, and interaction/accessibility/performance). These are proposals, not commitments:
+nothing here is started, and none of it is tracked in `BACKLOG.md` (that file is for agreed
+deferrals from shipped work; overlaps were checked and excluded). When an item ships, delete
+it here; if one gets started and deferred, move it to `BACKLOG.md` with the usual four fields.
+
+Sizes: **small** = under an hour, one file or two. **medium** = a focused PR.
+**big** = a feature with design decisions.
+
+**Cross-reference:** `HISTORY_PLAN.md` (the full-historization plan) has **SHIPPED** — all
+phases merged to `main` (PR #31, 2026-07-09). It absorbed item 13 outright (now done) and
+its snapshot spine is the prerequisite for items 12, 15, 18, 24, 25 and 26, which are now
+**unblocked** (each carries an updated `HISTORY_PLAN:` note) but not yet built.
+
+---
+
+## Big
+
+### 1. Transaction search
+There is no way to find a transaction by name, merchant or amount anywhere in the app; the
+only narrowing tools are the category drill-down and the account pill. With bank sync pulling
+in dozens of rows a month this is the largest daily-use gap.
+Where: `src/pages/BudgetPage.tsx` (ledger), `src/pages/DashboardPage.tsx` (recent list).
+Sketch: a text/amount filter box above the ledger, matching merchant + description + label,
+reusing `buildMatchHaystack` from `src/lib/text.ts`.
+
+### 2. Bulk select / bulk recategorize / bulk delete
+Every transaction is edited or deleted one modal at a time (`editDailyTransaction` /
+`removeDailyTransaction`). Cleaning up a mis-synced or mis-categorized batch is painful.
+Where: `src/pages/BudgetPage.tsx`.
+Sketch: checkbox multi-select on ledger rows with a floating action bar (set category, set
+label, delete). Pairs naturally with search (item 1): filter, select all, fix.
+
+### 3. Recurring-transaction detection
+The app already links transactions to fixed expenses via per-transaction "map to fixed
+expense" and guesses envelopes via `suggestEnvelopeLinks`, but nothing notices that the same
+merchant hits every month and suggests creating a fixed expense / envelope from it.
+Where: `src/lib/envelopes.ts`, `src/lib/transfers.ts` (pattern precedent),
+`src/pages/BudgetPage.tsx` (nudge UI, like the existing collision-detector nudge).
+Sketch: detect same-merchant, similar-amount, ~monthly cadence over the last 3+ months and
+offer one-tap "make this a fixed expense".
+
+### 4. Multi-arch Docker image (arm64)
+The publish workflow has no `platforms:` key, so `ghcr.io/...:latest` is amd64-only, and
+`better-sqlite3` is a native addon so there is no fallback. A friend on a Raspberry Pi can't
+run the prebuilt image at all, and Apple-Silicon Docker runs it under emulation.
+Where: `.github/workflows/build.yml` (buildx is already set up).
+Sketch: `platforms: linux/amd64,linux/arm64` on the build-push step.
+
+---
+
+## Medium
+
+### Daily use
+
+### 5. Quick-add for today's expense
+The Daily Tracker is collapsed by default (`logOpen` starts `false` in
+`src/pages/BudgetPage.tsx`), so logging today's coffee means expand, scroll to today, click
+the row's `+`. Add a persistent "quick add (today)" button (mobile FAB), or default the
+current month's log open.
+
+### 6. Remember last-used values in the add-transaction modal
+`addDailyTransaction` (`src/pages/BudgetPage.tsx`) always resets kind to `expense` with a
+blank category. Remembering the last-used category/kind (session-local is fine) removes the
+most repetitive taps in the app.
+
+### 7. Select-on-focus in edit modals
+`EditModal` (`src/components/EditModal.tsx`) focuses the first field but does not select its
+prefilled text, so every amount edit starts with manually clearing the old value. The inline
+`EditablePill` in `src/components/SmartRecommendations.tsx` already calls `.select()`; do the
+same on the modal's initial-focus input.
+
+### 8. Back button closes modals on mobile
+Open modals aren't tied to browser history (`src/components/ui/ModalShell.tsx`), so the
+hardware/browser Back button navigates the app away instead of dismissing the dialog. Push a
+history entry on open, close on `popstate`. One fix in ModalShell covers every modal.
+
+### 9. Undo instead of (or alongside) confirm for routine deletes
+Transaction/expense deletion shows a `ConfirmModal` each time but offers no recovery after.
+A toast-with-undo (hold the deleted row in memory for ~10s before committing) is both lighter
+for cleanup sessions and safer. Where: `src/pages/BudgetPage.tsx`, a small shared toast in
+`src/components/ui/`.
+
+### 10. Consistent delete protection
+Savings-account rows (`src/pages/AssetPage.tsx`, `removeSavingsAccount`) and payslips
+(`src/pages/BudgetPage.tsx`, `removePayslip`) delete instantly with no confirm, while fixed
+expenses, transactions, goals and debts all confirm. Align on one pattern (ideally item 9's
+undo) everywhere.
+
+### 11. Clickable Dashboard "Recent Transactions"
+The rows are plain divs (`src/pages/DashboardPage.tsx`), so fixing a wrong category means
+leaving for the Budget page and finding the row again. Wire the same edit modal the Budget
+ledger uses.
+
+### 12. Month in the URL
+The selected month lives only in app state, so a refresh or shared link always lands on the
+current month; "June's budget" can't be bookmarked. Reflect the month in the query string.
+Where: `src/components/Layout.tsx` (`currentMonth`).
+HISTORY_PLAN: unblocked — Phase 3's unified month model shipped (the header picker now
+drives `currentMonth` on Dashboard/Budget and `historyMonth` on balance pages); this just
+needs the active month reflected in the query string.
+
+### 13. One coherent month model across pages ✅ SHIPPED (PR #31)
+Delivered as Phase 3 (§5.1/§5.2) of `HISTORY_PLAN.md`: the stepper state was lifted to a
+shared `historyMonth` slice, the header month picker now drives the balance-page time
+machine on Assets/Loan/Pension (read-only, carries across pages), and the per-page
+`BalanceHistoryBar` was removed. (Salary is still always-live; not in scope.)
+
+### 14. Real empty state for salary sub-entries with no job
+Adding a bonus/overtime/hours entry before any job exists opens an `EditModal` whose only
+field is a disabled hint (`src/pages/SalaryPage.tsx`), which reads as a broken form. Replace
+with an inline "add a job first" CTA that opens the add-job modal.
+
+### Money insight & what-ifs
+
+### 15. Mortgage extra-payment what-if
+LoanPage renders a full year-by-year amortization schedule (`calcAmortizationSchedule`) but
+has no "pay X extra per month" control, even though `amortize` and DebtSection already prove
+the extra-payment pattern. A homeowner can't see that +2 000 kr/mo clears the loan N years
+early. Where: `src/pages/LoanPage.tsx`, `src/lib/debt.ts`.
+Sketch: an extra-payment slider on the amortization accordion showing months saved and
+interest saved vs the base schedule.
+HISTORY_PLAN: unblocked — Phase 4 §6.3 shipped `PaydownVsPlanChart` (plan-vs-actual) on
+LoanPage; this adds the extra-payment slider as a forward what-if layer over the same
+amortization schedule.
+
+### 16. Give `recurringTemplates` its UI
+`TransactionTemplate` and `recurringTemplates` are fully typed, persisted and exported
+(`src/context/FinanceContext.tsx`, `src/lib/exportSummary.ts`), and `addDailyTransaction`
+already accepts a template prefill, but no UI creates or applies templates. A "saved
+templates" quick-pick in the add-transaction modal would serve recurring manual entries
+(rent split, cash allowance).
+
+### 17. Marginal tax rate readout
+`calcNorwegianTax` exposes only the effective rate; the trinnskatt bracket structure needed
+for "your next krone is taxed at X%" is already in `src/lib/norwegianTax.ts`, and the
+marginal rate is already computed internally to fold bonuses into budget income. Surface it
+on SalaryPage so "is the extra shift worth it" is answerable.
+
+### 18. BSU cap tracking
+`assets.bsu` is a bare scalar summed into cash; nothing tracks the 27 500 kr/yr contribution
+cap, the 300 000 kr lifetime cap, or the age-34 cutoff. A BSU tile showing remaining room
+this year and lifetime would make the account actionable.
+Where: `src/context/FinanceContext.tsx` (`Assets.bsu`), Assets page.
+HISTORY_PLAN: unblocked — Phase 1 shipped, so `balanceSnapshots` now carries per-month BSU
+balances; "contributed this year" can be derived from the snapshot deltas rather than asked for.
+
+### 19. Restskatt early warning
+Each imported payslip stores that month's withheld tax (`MonthlyPayslip.tax`) and
+`calcNorwegianTax(gross).totalTax` computes the expected annual liability, but nothing
+compares them. A "withheld vs expected" tile could flag a likely restskatt (or refund)
+months before skatteoppgjøret.
+
+### 20. Feriepenger month modeling
+`monthlyCashflow` applies a flat income to every month, so the June feriepenger spike and
+the December half-trekk are invisible unless a payslip is imported for those months, even
+though `MonthlyPayslip.holidayPay` and the `holiday_pay` bonus type exist. Model the
+June/December swings in the budget projection (seeded from `feriepengesatsPct`).
+
+### 21. Saved forecast scenarios / A-B compare
+The five Forecast assumption sliders are local `useState`: a refresh loses them and two
+futures can't be held side by side (rate +2pp vs job change vs prepay). Persist assumptions
+and add a two-scenario compare (two projection lines plus a delta tile).
+Where: `src/pages/ForecastPage.tsx`.
+
+### 22. "Prepay mortgage vs invest" comparison
+The app computes interest saved from extra debt payments (`DebtSection.interestSaved`) and
+expected investment return (`ForecastPage.returnPct`) separately but never contrasts them,
+despite this being the most common spare-krone question in Norway (deductible interest).
+Sketch: a tile comparing "extra 5 000 kr/mo: prepay saves X (after 22% deduction) vs
+invest at Y% over N years".
+
+### 23. Scenario bands on projections
+Every net-worth projection (`calcNetWorthProjectionByBucket`) draws one deterministic line
+per bucket. Bear/base/bull bands (return ±3pp) around the long-range projection would stop
+the chart overstating certainty. Where: `src/lib/calculations.ts`,
+`src/pages/DashboardPage.tsx`, `src/pages/AssetPage.tsx`.
+
+### 24. Goal completion ETA from actual pace
+A goal knows its `remaining` and deadline (`GoalsSection.monthsUntil`), and the app computes
+recommended monthly savings, but nothing says "at your current pace you reach this by
+<date>" or "you're 4 months behind". Add a projected-completion ETA and a kr/mo-to-make-it
+suggestion.
+HISTORY_PLAN: unblocked — Phases 1-2 shipped; "actual pace" can now come from the snapshot
+history of the goal's source balance (`savingsSeriesFrom` / snapshot deltas), not from the
+recommended-savings figure.
+
+### 25. Financial-independence (FIRE) tile
+All inputs exist (net worth, annual essential expenses via `totalFixedExpenses`, the
+projection engine) but there's no "years to FI" or 25x-expenses readout. A FI tile on
+Forecast: net worth vs 25x annual essential spend, and the projected FI year at the current
+savings rate.
+HISTORY_PLAN: unblocked — Phase 2 shipped `netWorthSeriesFrom`; anchor the FI trajectory on
+that real net-worth history rather than the live number alone. (The Dashboard history-insights
+chips shipped in PR #31 are a lightweight precedent for this kind of derived readout.)
+
+### 26. Year-in-review report
+Per-year comp (`compByYear`), annual cashflow (`monthlyCashflow`) and multi-month category
+totals (`monthlyCategoryTotals`) all exist as pure functions, but there's no consolidated
+annual view (income, tax paid, savings rate, top categories, net-worth change) and no
+print/PDF path. Assemble a year-in-review page from the existing aggregators (pairs with
+the print stylesheet, item 63).
+HISTORY_PLAN: unblocked — the plan has landed (main); net-worth change and month-by-month
+balances now come straight from snapshots (`equitySeriesFrom` / `netWorthSeriesFrom`)
+instead of needing their own aggregation.
+
+### Data safety & self-hosting
+
+### 27. Corrupt-blob lockout recovery
+`readBlob()` guards the GET path, but the 409 stale-revision branch does an unguarded
+`JSON.parse(stored.content)`: once the single blob row is corrupt, reads serve `null` and
+every save 500s, so the user can neither read nor recover. Wrap the parse and fall through
+to last-write-wins (or quarantine the corrupt row). Where: `server/index.js` (409 branch).
+
+### 28. Snapshot before destructive operations
+JSON import (`importAll`), `resetAll`, and `make seed-reset` all overwrite or delete the
+live blob with no prior snapshot; the rev counter protects against concurrent writes, not
+intentional overwrites of good data. Auto-save a timestamped copy of the current blob before
+import/reset. Where: `src/pages/SettingsPage.tsx`, `server/index.js`, `Makefile`.
+
+### 29. Automated, rotating backups
+`make backup` is a single manual `docker cp` with no schedule, retention or rotation; a
+friend who forgets has exactly one live copy. Ship a compose sidecar or entrypoint cron that
+snapshots and prunes to N copies, or an in-app scheduled export. Where: `Makefile`,
+`docker-compose.yml`.
+
+### 30. One real version number and a version endpoint
+Three version numbers diverge (`APP_VERSION = '3.0.0'` in SettingsPage, `0.0.0` in
+package.json, `1.0.0` in server/package.json) and `/healthz` returns only `{ok}`, so "what
+version am I running" is unanswerable. CI already stamps `sha-<short>` image tags; expose
+build SHA via `/api/version` and render it in Settings About.
+
+### 31. In-app bank sync history
+`recordSync` overwrites `last_sync` and the sync route's `{fetched, added, total}` result is
+never persisted, so a self-hoster can't see whether the nightly cron ran or how many rows it
+pulled. Persist a small rolling sync log (timestamp, added count, ok/err) and render it in
+`BankSyncCard`. Where: `server/bank.js`, `src/components/BankSyncCard.tsx`.
+
+### 32. Compose resource limits and pinnable image docs
+`docker-compose.yml` sets no memory/CPU limits on a process that loads the whole blob into
+memory, and the README's update instructions only mention `:latest`, never the immutable
+`sha-` tags CI publishes, so friends can't pin or roll back. Add a modest `mem_limit` and
+document `sha-` pinning.
+
+### Accessibility
+
+### 33. Text alternatives for charts
+All 13 Recharts wrappers render bare SVG with no `role="img"`/`aria-label` and are not
+`aria-hidden`; a screen reader traverses unlabeled axis ticks (only `SpendingHeatmap` has
+per-cell labels). Wrap each container in `role="img"` with a one-line summary label.
+Where: `src/components/charts/*.tsx`.
+
+### 34. Skip-to-content link
+A keyboard user must Tab through the whole desktop nav on every route before reaching
+content. Add a visually-hidden "skip to content" as the first focusable element targeting
+`<main>`. Where: `src/components/Layout.tsx`.
+
+### 35. Persistent glossary for domain terms
+The only explanations of "headroom", LTV, trinnskatt, OTP/IPS live in the one-shot `learn`
+onboarding topics (`src/lib/onboarding.ts`); after `onboardingCompleted` there's no way to
+look a term up. Add inline info tooltips on domain labels or a glossary panel behind the
+existing header help button.
+
+### 36. Keyboard month-stepping and shortcuts
+The only keydown handlers are per-input Enter/Escape; the month stepper is two buttons
+requiring Tab+Enter. Add left/right arrow month stepping when the picker is focused, and
+optionally `g`-prefixed route jumps. Where: `src/components/Layout.tsx`.
+
+---
+
+## Small
+
+### Feedback & errors
+37. **Bank sync errors render in accent colour.** `syncError`/`linkError`/`keyInvalid` look
+    identical to success text (`src/components/BankSyncCard.tsx`, `color: var(--accent)`).
+    Use `var(--negative)` for error outcomes.
+38. **Silent wage-stats failure.** The SSB comparison line just vanishes on fetch failure
+    (`.catch(() => {})` in `src/context/FinanceContext.tsx`), unlike inflation which sets
+    `inflationStale`. Surface a small "benchmark unavailable" note.
+39. **No positive "saved" signal.** Saves are silent; only failures raise a banner
+    (`doSave` in `src/context/FinanceContext.tsx`). A subtle transient "saved" tick builds
+    trust that an edit persisted.
+40. **Skeletons for lazy routes/charts.** `RouteFallback` is a bare "…" (`src/App.tsx`) and
+    chart `Suspense` fallbacks are empty divs; slow first paint shows blank boxes.
+41. **Consent-expiry lead-time nudge.** `daysLeft` is computed per connection
+    (`server/bank.js`) but `BankSyncCard` only escalates once `needsRelink` is already true;
+    a cron-driven sync goes silent with no prior warning. Warn at e.g. 14 days remaining.
+
+### Input polish
+42. **Goals modal always shows the manual-current field** even when the goal source is
+    Portfolio/BSU/etc. (`src/components/GoalsSection.tsx`); needs conditional-field support
+    in `EditModal` or a filtered field list.
+43. **Goal deadline is free-text `YYYY-MM`** (`src/components/GoalsSection.tsx`); use
+    `<input type="month">`.
+44. **Slider vs number-input caps disagree.** Savings-target slider caps at 95
+    (`src/pages/SettingsPage.tsx`) while the inline % editor allows 100
+    (`src/components/SmartRecommendations.tsx`) and `RangeRow`'s number input has no upper
+    cap. Reconcile.
+45. **Fixed-expense match pattern only settable from a transaction.** The "map to fixed
+    expense" rule can't be added or edited from the fixed-expense editor itself
+    (`src/pages/BudgetPage.tsx`). Add a match field there.
+46. **EditModal has no `<form>` semantics.** Enter-to-submit is wired per input
+    (`src/components/EditModal.tsx`), so the checkbox field and suggestion chips don't
+    submit and there's no `type="submit"`. Wrap fields in a `<form onSubmit>`.
+47. **Backdrop-click discards in-progress edits.** `ModalShell` closes on any overlay click
+    with no dirty guard, so a mis-tap throws away a half-typed amount (the onboarding tour
+    deliberately guards leaving). Suppress backdrop-close when dirty, or confirm.
+
+### Reading & copying
+48. **Global `user-select: none` blocks copying figures.** A user can't copy their net-worth
+    number or an account tail from a card (`src/index.css`; only inputs and `[data-selectable]`
+    opt back in). Add `data-selectable` to key monetary/identifier readouts.
+49. **Tiny touch targets on ledger row actions.** Edit/delete icons are 11-12px inside chips
+    (`src/pages/BudgetPage.tsx`), far under the ~44px mobile guideline. Pad the hit areas.
+
+### Charts & PWA
+50. **AssetPage projection legend colour mismatch.** The legend's crypto swatch uses
+    `var(--negative)` while the stacked area uses `CHART.rust` (`src/pages/AssetPage.tsx`).
+    Use the same token.
+51. **Legends aren't interactive.** No click-to-isolate/toggle on the multi-series projection
+    charts (`src/pages/AssetPage.tsx`, `src/components/SmartRecommendations.tsx` has
+    hover-dim only).
+52. **UpdatePrompt bypasses i18n.** "Ny versjon tilgjengelig / New version available" is
+    hardcoded bilingual (`src/components/UpdatePrompt.tsx`); move to `translations.ts`.
+53. **CSV export is current-month only.** `exportCSV` filters to the selected month
+    (`src/pages/BudgetPage.tsx`); offer a full-history export.
+54. **Recharts animations ignore `prefers-reduced-motion`.** The reduced-motion CSS block
+    only neutralizes CSS transitions, not Recharts' JS-driven tweens; pass
+    `isAnimationActive={!reduced}` from a media-query hook.
+55. **No `color-scheme: dark`.** `:root` sets dark tokens but never declares `color-scheme`,
+    so native UI (select popups, number spinners, month pickers, autofill) renders light
+    against the dark app (`src/index.css`).
+56. **No print stylesheet.** Pages print dark-on-dark with the sticky header and bottom nav
+    overlapping content; add an `@media print` block (light background, hide chrome). Pairs
+    with the year-in-review report (item 26).
+
+### Norwegian domain
+57. **Studielån is only a generic debt.** The `student` debt type is amortized like any loan
+    (`src/lib/debt.ts`), ignoring Lånekassen specifics (0% while studying, deferment), so its
+    payoff row can mislead. Model the subtype's basics.
+58. **Forecast ignores the user's tuned assumptions.** Slider defaults are hardcoded
+    (return 5%, savings 25%) even though the context carries the user's `growthReturnRate`
+    and `savingsTargetPercent`; the Dashboard even nags about untuned defaults while
+    Forecast uses different numbers. Seed the sliders from the user's values.
+59. **No savings-rate decline warning.** The 12-month savings-rate series is computed and
+    charted, but nothing flags the trailing rate falling under `savingsTargetPercent`. Add a
+    banner/chip on Budget or Dashboard.
+60. **Emergency-fund months use fixed expenses only.** `calcEmergencyFundStatus(bufferAccount,
+    totalFixedExpenses)` counts discretionary subscriptions but ignores variable essentials
+    (groceries), so "months covered" can mislead both ways. Let the user mark essential lines
+    or include median variable spend.
+61. **Fixed expenses are typed but never totaled by type.** Each carries
+    `fixed | variable | subscription | insurance` with a coloured dot, but there is no
+    "subscriptions cost you X kr/mo" summary (`src/pages/BudgetPage.tsx`). Add per-type
+    totals above the list.
+
+### Self-hosting
+62. **Blob/DB size not surfaced.** The server warns at 2 MB in the log only; the Settings
+    About card shows a static "Storage: SQLite" chip. Show live blob bytes plus record
+    counts (already computed by `summarizeExport`).
+63. **Export stamps `_version: 1` but import never checks it.** `validateAndPreview`
+    (`src/pages/SettingsPage.tsx`) ignores the field, so a future format change would import
+    silently. Gate on `_version` and warn on newer-than-supported files.
+64. **Import is all-or-nothing.** The preview diff is good, but `confirmImport` replaces the
+    whole payload; a per-section selective restore (just the ledger, just settings) would
+    pair naturally with the existing diff summary.
+65. **SSB inflation has no manual refresh.** The retry cooldown lives in memory
+    (`server/index.js`), so after an outage the user can't force a fetch short of restarting
+    the container. Add a "refresh" action that resets the cooldown.
+66. **Restore is shell-only.** Recovering a SQLite snapshot is documented as
+    `docker cp` + restart (`README.md`); an in-app restore path (or surfacing the last
+    auto-snapshot from item 28) would make recovery reachable without a terminal.
+
+### Accessibility & i18n leaks
+67. **Hardcoded-English aria/copy leaks:** month-stepper `aria-label="Previous/Next month"`
+    (`src/components/Layout.tsx`), `aria-label="Budget composition"` and the visible
+    "vs avg" chip text (`src/pages/DashboardPage.tsx`), and the mobile CSV button whose
+    label is hidden below `sm` leaving a bare icon with no `aria-label`
+    (`src/pages/BudgetPage.tsx`). Route all through `translations.ts`.
+68. **Ledger table headers lack `scope="col"`** (`src/pages/BudgetPage.tsx` and the other
+    `<th>` sites). Add scope attributes.
+69. **Onboarding always restarts from the top.** Only the `onboardingCompleted` boolean
+    persists; re-entering the tour begins at welcome even mid-setup
+    (`src/components/onboarding/OnboardingTour.tsx`). Persist the last topic index and
+    resume.
+70. **Optional: explicit vendor `manualChunks`.** Charts and pdf.js are already lazy; an
+    explicit recharts/date-fns vendor split in `vite.config.ts` would make the shared-chunk
+    boundary stable across builds. Low priority.
+
+---
+
+## Checked and fine (don't re-investigate)
+
+- **Bundle/lazy-loading**: every chart is `lazy()`-imported per component, so Recharts stays
+  out of the entry chunk; pdf.js is lazy per BACKLOG.
+- **Ledger DOM size**: the Budget ledger renders one row per day of the selected month, not
+  a year of transactions; no virtualization needed.
+- **PWA update path**: `registerType: 'prompt'` + hourly/visibility polling +
+  `controllerchange` fallback + the stale-chunk 404 guard are all in place.
+- **Input handling**: `inputMode="decimal"`, `parseLocaleNumber` comma handling, the iOS
+  16px font floor, focus trap/restore and `prefers-reduced-motion` (CSS side) are solid.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,5 +1,11 @@
 # Headroom, maths & value-population audit (2026-07-07)
 
+> **Status (2026-07-09): effectively complete.** Every 🔴/🟡 finding and all of sections
+> 1–4, 6 and 8 are ✅ FINISHED. Sections 5.6/5.7 were re-verified against `main` and closed
+> out. Genuinely remaining, all intentional: `deletedBankIds` pruning (§5.7, BACKLOG-tracked
+> as provably unsafe), the bank twin-dedup shims (§5.6/§7, kept until the blob converges), the
+> `SalaryPage.trailingHourly` extraction (§5.1, do when next touched), and §8.8 (won't-do).
+
 Full pass over how every number is computed and how values flow into charts, tables and tiles,
 motivated by the app being shared (friends now self-host their own instances, each
 single-user). Covered:
@@ -338,40 +344,47 @@ of CHART values). CSS contexts where `var()` would already work: `FunBudget`,
 `GoalsSection.tsx:195`, `EditModal`, `NetWorthHistoryModal`, `CategoryBreakdown.tsx:29`,
 `DashboardPage.tsx:566` `#0E1310`, plus recurring `rgba(255,255,255,0.0x)` backgrounds.
 
-**5.6 🟢 Duplication worth one extraction each.**
-- Padded-lowercase haystack built identically in `categorize.ts`, `envelopes.ts`,
-  `labelRules.ts` (the word-boundary padding trick is documented in only one).
-- Twin-dedup logic maintained twice: `src/lib/bankDedup.ts:13-14` (TS) and
-  `server/bank.js:339-340` (`dropStaleBareTwins`, CJS); the regexes must stay
-  byte-equivalent. Also the `BARE` regex misclassifies a legacy ref that happens to start
-  with 8 hex chars + `-` as prefixed.
-- "Latest salary ≤ month" selection in both `src/lib/salary.ts:4-8` (`salaryAt`) and
-  `FinanceContext.tsx:238-243` (`calcActiveGrossAnnual`).
-- `SummaryTile`/`NumberRow`/`SliderRow` copy-pasted across `PensionPage.tsx:253-358`,
-  `EmployerCostPage.tsx:221-313`, ForecastPage, plus two more `SummaryTile` variants at
-  `SalaryPage.tsx:1316` and `LoanPage.tsx:945` (five total); `formatAxisInt` defined in
-  PensionPage, ForecastPage, and inline in AssetPage.
-- `BudgetPage.tsx:171` recomputes `totalFixedExpenses` locally; the context already exports
-  the identical memo (`FinanceContext.tsx:1160-1162`). Same for `incomeDiffPct`
-  (`BudgetPage.tsx:435` = `DashboardPage.tsx:89`).
+**5.6 🟢 Duplication worth one extraction each.** (all closed except the two shims below)
+- ✅ FINISHED (verified on main 2026-07-09) Match haystack: `categorize.ts` and `labelRules.ts`
+  now share `buildMatchHaystack` (`src/lib/text.ts`). `envelopes.ts` keeps a distinct
+  single-name padded haystack (matches a fixed-expense name, not a merchant+description tx),
+  which is a different input, not the same code.
+- Twin-dedup logic maintained twice: `src/lib/bankDedup.ts` (TS) and `server/bank.js`
+  (`dropStaleBareTwins`, CJS); the regexes must stay byte-equivalent. **Kept by design** —
+  the retirement plan (§7) shrinks this only after 2.3 converges the stored blob. The `BARE`
+  misclassification is tracked in `BACKLOG.md` as provably unsafe to disambiguate.
+- ✅ FINISHED (verified on main 2026-07-09) "Latest salary ≤ month" selection: `calcActiveGrossAnnual`
+  (`FinanceContext.tsx`) now calls the shared `salaryAt` (`src/lib/salary.ts`).
+- ✅ FINISHED (verified on main 2026-07-09) The shared cases are extracted to
+  `src/components/ui/` (`NumberRow`, `SummaryTile`, `SliderRow`, used by Pension/EmployerCost)
+  and `formatAxisInt` to `src/lib/format.ts` (all pages import it). The remaining page-local
+  `SummaryTile`s (ForecastPage now-vs-then, LoanPage value+accent, SalaryPage value+sub+chip)
+  are genuinely different prop shapes — see §8.8: a shared slot would be a bigger abstraction
+  than the duplication it removes.
+- ✅ FINISHED (verified on main 2026-07-09) `BudgetPage` consumes the context `totalFixedExpenses`
+  memo and the shared `incomeDiffPct` (`src/lib/income.ts`, also used by DashboardPage).
 
-**5.7 🟢 Small hygiene items.** (four fixed in f43420f, marked below)
+**5.7 🟢 Small hygiene items.** (four fixed in f43420f; the rest verified done on
+2026-07-09 — only `deletedBankIds`, BACKLOG-tracked as unsafe to prune, remains open)
 - ✅ FINISHED (f43420f) `debt.ts:30-39` `amortize` reports the 600-month cap as
   `months=600, feasible=false` while `planPayoff` uses `Infinity`. Mirrored, incl.
   `perDebt[].payoffMonth`.
-- `validators.ts` `isPositiveNumber` accepts 0 (misleading name); `parseLocaleNumber`
-  rejects thousands-space while `coerceNumber` accepts it (two locale grammars).
-- `calculations.ts` `HomeownerStatus.equityPercent` is actually "% of original loan repaid";
-  rename before someone uses it as equity.
+- ✅ FINISHED (verified on main 2026-07-09) `validators.ts` `isPositiveNumber` renamed
+  `isNonNegativeNumber` (name now matches the accepts-0 behavior); the `parseLocaleNumber`
+  vs `coerceNumber` split is documented as deliberate in `validators.ts:35-40`.
+- ✅ FINISHED (verified on main 2026-07-09) `calculations.ts` `HomeownerStatus.equityPercent`
+  renamed `originalLoanRepaidPercent`, with a comment noting it is not home equity.
 - ✅ FINISHED (f43420f) `ForecastPage.tsx:141` leftover `void jobs;` removed.
-- `SettingsPage.tsx:98-100` currency inputs (`usdRateInput`/`customRateInput`) are seeded
-  once from context and never resync after a JSON import or demo toggle; `RangeRow` in the
-  same file shows the resync-effect pattern to copy.
-- `currentMonthKey()` inside `useMemo` with no time dep pins "current" across a month
-  boundary in a long-lived session (`PensionPage.tsx:38-41`, `ForecastPage.tsx:25-37`,
-  `EmployerCostPage.tsx:24-27`; cosmetic).
-- `deletedBankIds` grows unboundedly (`FinanceContext.tsx:751,823`); prune ids no longer
-  present in the stored blob.
+- ✅ FINISHED (verified on main 2026-07-09) `SettingsPage.tsx` currency inputs now resync via
+  `useEffect` on `nokToUsd`/`customCurrencyCode`/`customCurrencyRate` (lines 105-109), so a
+  JSON import or demo toggle updates the fields.
+- ✅ FINISHED (verified on main 2026-07-09) `currentMonthKey()` moved out of `useMemo` into
+  render scope in all three pages (`PensionPage.tsx:40`, `ForecastPage.tsx:24`,
+  `EmployerCostPage.tsx:30`), each with a comment on the month-rollover rationale and `today`
+  in the dependent memos' dep arrays.
+- `deletedBankIds` grows unboundedly (`FinanceContext.tsx`); still open, but tracked in
+  `BACKLOG.md` where it is documented as provably unsafe to prune (a dropped id absent from
+  the blob would let the server's reconcile resurrect the deleted row).
 - ✅ FINISHED (f43420f) `resetAll` re-hardcodes `37.84/22/5/7/67`; now uses
   `DEFAULT_ASSETS`/`DEFAULT_PENSION` (loan/homeowner/transition keep zero literals — their
   DEFAULT_* constants hold non-zero example values, wrong for a wipe).
@@ -549,8 +562,8 @@ shape; leave them.
 `DashboardPage.tsx:331,421,446,496` (abs variant at :261). Fix: `formatSignedPct(v, digits
 = 1)` in a new `src/lib/format.ts`; makes null → em-dash handling consistent.
 
-**8.8 🟢 Editable label/value row triplicated.** *(Assessed 2026-07-08, recommend dropping:
-beyond the wrapper classes the rows share almost nothing — LoanRow carries its own
+**8.8 ✅ WON'T DO (decision recorded 2026-07-08) Editable label/value row triplicated.**
+*(Beyond the wrapper classes the rows share almost nothing — LoanRow carries its own
 highlight/calculated colour logic + notes, SavingsAccountRow uses real buttons for a11y —
 so a slot component would be a bigger abstraction than the duplication it removes.)*
 `AssetPage.tsx:598-621` (AssetRow), `:624-673` (SavingsAccountRow),

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -5,6 +5,13 @@
 > out. Genuinely remaining, all intentional: `deletedBankIds` pruning (§5.7, BACKLOG-tracked
 > as provably unsafe), the bank twin-dedup shims (§5.6/§7, kept until the blob converges), the
 > `SalaryPage.trailingHourly` extraction (§5.1, do when next touched), and §8.8 (won't-do).
+>
+> **Full re-verification (2026-07-09):** every ✅ FINISHED item in sections 1–8 was
+> independently checked against the current code (not the commit messages). All confirmed
+> in place. One residual surfaced and was fixed in the same pass: the last stray hex from
+> §5.5 (`#0E1310` in `SmartRecommendations.tsx`) is now `var(--bg)`; the other §5.5
+> leftovers (ConfirmModal danger hover, surface overlays) had already been tokenised in
+> 9dd67a7. Forward-looking UX/feature ideas from the same pass live in `FEATURES.md`.
 
 Full pass over how every number is computed and how values flow into charts, tables and tiles,
 motivated by the app being shared (friends now self-host their own instances, each
@@ -238,6 +245,11 @@ recorded then — and the live debt editor is hidden while time-travelling.)
 `AssetPage.tsx:90-93` uses live `totalDebt` (and a fully-live `EquityCompositionBar`) even
 when rendering a historical snapshot; LoanPage gates on `hist.isLive` correctly. Fix: gate
 like LoanPage; long-term, snapshotting debts (the BACKLOG item in 4.1) makes history honest.
+_Extended by PR #31 (full historization): the time machine was lifted to a shared
+`historyMonth` and unified into the header month picker (one control across Assets/Loan/
+Pension), and the remaining history-mode live-data leaks were closed (AssetPage projections
+now read the snapshot's `assumptions`/rate/term; PensionPage income resolves at the viewed
+month)._
 
 **4.6 ✅ FINISHED (616837c) Old balance snapshots can render NaN in the composition chart.**
 `computeEquityBreakdown` does no field guarding and
@@ -245,6 +257,10 @@ like LoanPage; long-term, snapshotting debts (the BACKLOG item in 4.1) makes his
 saved before a field existed (`cryptoUnrealizedGain`, `bufferAccount`, ...) yields
 `undefined * n → NaN` in the bar. `sanitizePayload` also skips snapshot internals (see 2.1).
 Fix: `?? 0` each field inside `computeEquityBreakdown`; cheapest, covers all callers.
+_Extended by PR #31 (full historization): the same finite-or-0 guard now wraps every new
+snapshot reader (`netWorthFromSnapshot` debt balances, `paydownVsPlan`/`debtPaydownVsPlan`
+mortgage & debt reads, `LtvChart` actual series, `snapshotSeries`), so a hand-edited/missing
+balance or NaN rate can't reach the new derived-history charts either._
 
 **4.7 ✅ FINISHED (e2a27bf) Salary YoY tiles fabricate "+0.0%" with short history.**
 With fewer than 13 months of data, `yoy` returns zeros instead of null, so a new user sees a
@@ -333,10 +349,12 @@ BudgetPage does it right).
 - ✅ FINISHED (8c1264e) `PayslipImportModal.tsx:169,236`: literal "Visma" badge instead of
   the provider-registry name.
 
-**5.5 ✅ FINISHED (a7c76e8, via 8.3) Hardcoded hex colours outside `chartColors.ts`.**
-(SVG contexts now use CHART.* via the 8.3 prop blocks; CSS contexts use theme vars. Left:
-ConfirmModal's bespoke `#9c4632` danger hover (no token) and the recurring
-`rgba(255,255,255,0.0x)` backgrounds, which need a new token rather than a swap.)
+**5.5 ✅ FINISHED (a7c76e8, via 8.3; fully closed 2026-07-09) Hardcoded hex colours outside `chartColors.ts`.**
+(SVG contexts now use CHART.* via the 8.3 prop blocks; CSS contexts use theme vars. The
+former leftovers are closed: the ConfirmModal danger hover and the `rgba(255,255,255,0.0x)`
+surface overlays got tokens in 9dd67a7, and the last stray `#0E1310` in
+`SmartRecommendations.tsx` (allocation-strip label) became `var(--bg)` on 2026-07-09.
+The only remaining raw rgba is the documented token mirror in `chartColors.ts`.)
 SVG contexts that should use the `CHART.*` mirror: `SalaryPage` (axis `#5F6555`, grid
 `#262A20`, comp-chart gradient hexes), `PensionPage.tsx:147-166`,
 `ForecastPage.tsx:237-268`, `DebtSection.tsx`, `BudgetDistributionChart.tsx` (local copies

--- a/src/components/SmartRecommendations.tsx
+++ b/src/components/SmartRecommendations.tsx
@@ -266,7 +266,7 @@ export default function SmartRecommendations() {
                   style={{
                     width: `${pct}%`,
                     background: entry.color,
-                    color: '#0E1310',
+                    color: 'var(--bg)',
                     opacity: hoveredSlice === null || hoveredSlice === i ? 1 : 0.4,
                   }}
                   onMouseEnter={() => setHoveredSlice(i)}


### PR DESCRIPTION
## Why

`IMPROVEMENTS.md` (the 2026-07-07 maths & value-population audit) still listed several items as open, but they were fixed in the meantime and the doc had gone stale.

## What

Re-verified every non-FINISHED item against `main` and closed them out:

- §5.7 — `equityPercent` → `originalLoanRepaidPercent`; currency inputs resync via effects; `currentMonthKey()` moved to render scope in the three pages; `isPositiveNumber` → `isNonNegativeNumber`. All verified present on `main`.
- §5.6 — match haystack shared via `lib/text.buildMatchHaystack`; `calcActiveGrossAnnual` uses `salaryAt`; `NumberRow`/`SummaryTile`/`SliderRow` and `formatAxisInt` extracted to `ui/` and `lib/format`; `BudgetPage` uses the context `totalFixedExpenses` memo + shared `incomeDiffPct`.
- §8.8 — recorded as WON'T DO (the three rows have genuinely different shapes; a slot component would be a net-negative abstraction).
- Added a status banner: the audit is effectively complete.

No code changes — documentation only. Genuinely remaining items are all intentional: `deletedBankIds` pruning (BACKLOG-tracked as provably unsafe), the bank twin-dedup shims (kept until the blob converges), and the `trailingHourly` extraction (do when next touched).

## Verification

Doc-only change; no build gate needed. Cross-checked each closed item against the current source on `main`.