### PR TITLE
fix(nav): keep header tabs centered when the time marker is hidden

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -125,7 +125,7 @@ const Layout: React.FC = () => {
         style={{ background: 'var(--bg)', borderColor: 'var(--rule)' }}
       >
         {/* Brand — ceiling/clearance mark (a ring bisected by a hairline) + serif wordmark */}
-        <div className="flex items-center gap-2.5 shrink-0">
+        <div className="flex items-center gap-2.5 shrink-0 md:flex-1 md:min-w-0">
           <span
             className="relative grid place-items-center w-[18px] h-[18px] rounded-full shrink-0"
             style={{ border: '1px solid var(--brass)' }}
@@ -140,14 +140,14 @@ const Layout: React.FC = () => {
         </div>
 
         {/* Underline tabs — desktop only */}
-        <nav className="hidden md:flex items-center gap-7">
+        <nav className="hidden md:flex items-center gap-7 shrink-0">
           {NAV_ITEMS.filter(item => isVisible(item.path)).map(item => (
             <NavButton key={item.path} to={item.path} label={t.nav[item.key]} />
           ))}
         </nav>
 
         {/* Right cluster: month picker (month-scoped pages) or static "as of today" marker */}
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex items-center gap-2 shrink-0 md:flex-1 md:min-w-0 md:justify-end">
           {/* Setup guide — desktop header (mobile uses the "More" sheet entry to
               avoid crowding the month picker). Always available so the tour can
               be (re)started with data too. */}


### PR DESCRIPTION
## Why
On the **År** and **Innstillinger** tabs the whole nav bar sits in a different horizontal position than on every other tab — the tab row visibly shifts sideways when you switch to those pages.

Cause: the desktop header is `justify-between` with three children — brand, nav, right cluster. The right cluster's width varies by page: `/year` and `/settings` are in `HIDE_TIME_MARKER_ROUTES`, so they hide the "Per i dag · <date>" marker and leave only the two header icons, while every other page shows the wider marker. With `justify-between` the centered nav sits at the midpoint between the two clusters, so a narrower right cluster drags the tab row toward it.

## What
Make the two side clusters equal-width flex columns at desktop width (`md:flex-1 md:min-w-0`, right cluster `md:justify-end`), so the nav centers in the viewport independent of what the right cluster contains. Mobile is untouched: the nav is `hidden` below `md` and the clusters stay `shrink-0`, so the existing `justify-between` spacing is preserved there.

Single-file change in `src/components/Layout.tsx` (3 className edits).

## Verification
`tsc -b` + lint clean. Built the Docker image and compared the header across `/year` (marker hidden) and `/forecast` (marker shown) at 1440px — the tab row now sits in the identical centered position on both, 0 console errors.