### PR TITLE
feat(ui): use the calendar date picker for every date field

### DIFF
--- a/src/components/DebtSection.tsx
+++ b/src/components/DebtSection.tsx
@@ -61,7 +61,7 @@ export default function DebtSection() {
     { key: 'minPayment', label: d.minPayment, type: 'number', value: val.minPayment != null ? String(val.minPayment) : '' },
     // Lånekassen interest-free/deferred month — only meaningful for student loans.
     {
-      key: 'interestFreeUntil', label: d.interestFreeLabel, type: 'month',
+      key: 'interestFreeUntil', label: d.interestFreeLabel, type: 'monthpicker', pickerMode: 'month',
       value: val.interestFreeUntil ?? '', hint: d.interestFreeHint,
       showWhen: (v) => v.type === 'student',
     },

--- a/src/components/EditModal.tsx
+++ b/src/components/EditModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useId, type Ref, type ReactNode } from 'react';
 import { useFinance } from '../context/FinanceContext';
 import { ModalShell } from './ui/ModalShell';
 import { MonthPicker } from './ui/MonthPicker';
+import { normalizeMonthOrDay } from '../lib/dateInput';
 
 export interface ModalFieldOption {
   value: string;
@@ -58,7 +59,17 @@ export default function EditModal({ title, fields, onSave, onCancel, cancelLabel
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSave(values);
+    // Canonicalise month-picker fields (2022-7-15 → 2022-07-15, 15.07.2022 →
+    // 2022-07-15) so each caller's own validation sees a tidy value. Genuinely
+    // unparseable input is left as-is for the caller to reject.
+    const canonical = { ...values };
+    for (const f of fields) {
+      if (f.type === 'monthpicker') {
+        const n = normalizeMonthOrDay(canonical[f.key], f.pickerMode ?? 'month');
+        if (n !== null) canonical[f.key] = n;
+      }
+    }
+    onSave(canonical);
   };
 
   return (

--- a/src/components/GoalsSection.tsx
+++ b/src/components/GoalsSection.tsx
@@ -133,7 +133,7 @@ const GoalsSection: React.FC = () => {
           // current value from the linked balance, so hide the manual entry.
           showWhen: (v) => decodeSource(v.source).source === 'manual',
         },
-        { key: 'deadline', label: t.goals.deadline, type: 'month', value: existing?.deadline ?? '', placeholder: '2027-12' },
+        { key: 'deadline', label: t.goals.deadline, type: 'monthpicker', pickerMode: 'month', value: existing?.deadline ?? '', placeholder: '2027-12' },
         { key: 'notes', label: t.goals.notes, type: 'text', value: existing?.notes ?? '' },
       ],
       onSave: (vals) => {

--- a/src/components/RecordEventModal.tsx
+++ b/src/components/RecordEventModal.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useRef, useState } from 'react';
 import { TrendingUp } from 'lucide-react';
 import { ModalShell } from './ui/ModalShell';
+import { MonthPicker } from './ui/MonthPicker';
+import { normalizeMonthOrDay } from '../lib/dateInput';
 import {
   useFinance,
   type SalaryEntry, type SalaryChangeType,
@@ -138,22 +140,24 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
 
   const handleSave = () => {
     if (entity === 'salary') {
-      if (!isValidYearMonth(effectiveDate)) return setError(t.salaryPage.errInvalidDateMonth);
+      const eff = normalizeMonthOrDay(effectiveDate, 'month');
+      if (eff === null || !isValidYearMonth(eff)) return setError(t.salaryPage.errInvalidDateMonth);
       if (newGross == null || newGross < 0) return setError(t.salaryPage.errSalaryPositive);
       const payload = {
         jobId,
-        effectiveDate,
+        effectiveDate: eff,
         grossAnnual: newGross,
         changeType: editing ? salaryChangeType : (selType as SalaryChangeType),
         notes: notes.trim() || undefined,
       };
       if (sTarget) updateSalary(sTarget.id, payload); else addSalary(payload);
     } else if (entity === 'bonus') {
-      if (!isValidYearMonthDay(bonusDate)) return setError(t.salaryPage.errInvalidDateDay);
+      const bd = normalizeMonthOrDay(bonusDate, 'day');
+      if (bd === null || !isValidYearMonthDay(bd)) return setError(t.salaryPage.errInvalidDateDay);
       if (!isNonNegativeNumber(bonusAmount)) return setError(t.salaryPage.errAmountPositive);
       const payload = {
         jobId: jobId || undefined,
-        date: bonusDate,
+        date: bd,
         amount: parseLocaleNumber(bonusAmount),
         type: bonusType,
         includeInBudget: bonusInclude || undefined,
@@ -161,11 +165,12 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
       };
       if (bTarget) updateBonus(bTarget.id, payload); else addBonus(payload);
     } else if (entity === 'overtime') {
-      if (!isValidYearMonthDay(otDate)) return setError(t.salaryPage.errInvalidDateDay);
+      const od = normalizeMonthOrDay(otDate, 'day');
+      if (od === null || !isValidYearMonthDay(od)) return setError(t.salaryPage.errInvalidDateDay);
       if (!isNonNegativeNumber(otHours) || !isNonNegativeNumber(otAmount)) return setError(t.salaryPage.errHoursAmountPositive);
       const payload = {
         jobId: jobId || undefined,
-        date: otDate,
+        date: od,
         hours: parseLocaleNumber(otHours),
         amount: parseLocaleNumber(otAmount),
         includeInBudget: otInclude || undefined,
@@ -173,11 +178,12 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
       };
       if (oTarget) updateOvertime(oTarget.id, payload); else addOvertime(payload);
     } else {
-      if (!isValidYearMonth(hoursMonth)) return setError(t.salaryPage.errInvalidMonth);
+      const hm = normalizeMonthOrDay(hoursMonth, 'month');
+      if (hm === null || !isValidYearMonth(hm)) return setError(t.salaryPage.errInvalidMonth);
       if (!isNonNegativeNumber(hoursValue)) return setError(t.salaryPage.errHoursPositiveShort);
       const payload = {
         jobId: jobId || undefined,
-        periodMonth: hoursMonth,
+        periodMonth: hm,
         actualHoursPerWeek: parseLocaleNumber(hoursValue),
         notes: notes.trim() || undefined,
       };
@@ -276,8 +282,8 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
         {entity === 'salary' && (<>
           <div className="space-y-1.5">
             <label htmlFor="re-eff" className={labelClass}>{t.salary.effectiveDate}</label>
-            <input id="re-eff" ref={firstRef} type="text" value={effectiveDate} placeholder="2024-04"
-              onChange={(e) => setEffectiveDate(e.target.value)} onKeyDown={onKeyDown} className={inputMono} />
+            <MonthPicker id="re-eff" inputRef={firstRef} mode="month" value={effectiveDate} placeholder="2024-04"
+              onChange={setEffectiveDate} onKeyDown={onKeyDown} />
           </div>
           {jobs.length > 1 && jobField}
           <div className="space-y-1.5">
@@ -321,8 +327,8 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
         {entity === 'bonus' && (<>
           <div className="space-y-1.5">
             <label htmlFor="re-bd" className={labelClass}>{t.salary.bonusDate}</label>
-            <input id="re-bd" ref={firstRef} type="text" value={bonusDate} placeholder="2024-06-15"
-              onChange={(e) => setBonusDate(e.target.value)} onKeyDown={onKeyDown} className={inputMono} />
+            <MonthPicker id="re-bd" inputRef={firstRef} mode="day" value={bonusDate} placeholder="2024-06-15"
+              onChange={setBonusDate} onKeyDown={onKeyDown} />
           </div>
           {jobs.length > 1 && jobField}
           <div className="space-y-1.5">
@@ -342,8 +348,8 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
         {entity === 'overtime' && (<>
           <div className="space-y-1.5">
             <label htmlFor="re-od" className={labelClass}>{t.salary.overtimeDate}</label>
-            <input id="re-od" ref={firstRef} type="text" value={otDate} placeholder="2024-06-15"
-              onChange={(e) => setOtDate(e.target.value)} onKeyDown={onKeyDown} className={inputMono} />
+            <MonthPicker id="re-od" inputRef={firstRef} mode="day" value={otDate} placeholder="2024-06-15"
+              onChange={setOtDate} onKeyDown={onKeyDown} />
           </div>
           {jobs.length > 1 && jobField}
           <div className="flex gap-2">
@@ -363,8 +369,8 @@ export default function RecordEventModal({ target, initialType, onClose, onNewJo
         {entity === 'hours' && (<>
           <div className="space-y-1.5">
             <label htmlFor="re-hm" className={labelClass}>{t.salary.periodMonth}</label>
-            <input id="re-hm" ref={firstRef} type="text" value={hoursMonth} placeholder="2024-06"
-              onChange={(e) => setHoursMonth(e.target.value)} onKeyDown={onKeyDown} className={inputMono} />
+            <MonthPicker id="re-hm" inputRef={firstRef} mode="month" value={hoursMonth} placeholder="2024-06"
+              onChange={setHoursMonth} onKeyDown={onKeyDown} />
           </div>
           {jobs.length > 1 && jobField}
           <div className="space-y-1.5">

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -12,6 +12,7 @@ import { DEBT_TYPES } from '../../lib/debt';
 import PayslipImportModal from '../PayslipImportModal';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { ProgressBar } from '../ui/ProgressBar';
+import { MonthPicker } from '../ui/MonthPicker';
 import { parseLocaleNumber, isValidYearMonth } from '../../lib/validators';
 import { CATEGORIES, isCategoryKey } from '../../lib/categories';
 import {
@@ -472,7 +473,7 @@ function JobSalaryAdder() {
       </div>
       <div className="space-y-1.5">
         <label className={microLabel} style={{ color: 'var(--text-2)' }}>{o.fields.startMonth}</label>
-        <input value={start} onChange={e => setStart(e.target.value)} placeholder="2026-07" className={`${inputCls} font-mono`} style={inputStyle} />
+        <MonthPicker mode="month" value={start} onChange={setStart} placeholder="2026-07" />
       </div>
       <div className="space-y-1.5">
         <label className={microLabel} style={{ color: 'var(--text-2)' }}>{o.fields.grossAnnual}</label>
@@ -481,7 +482,7 @@ function JobSalaryAdder() {
       <Collapsible label={o.advancedSettings}>
         <div className="space-y-1.5">
           <label className={microLabel} style={{ color: 'var(--text-2)' }}>{t.salary.endDate}</label>
-          <input value={end} onChange={e => setEnd(e.target.value)} placeholder="2028-06" className={`${inputCls} font-mono`} style={inputStyle} />
+          <MonthPicker mode="month" value={end} onChange={setEnd} placeholder="2028-06" />
         </div>
         <div className="flex gap-2">
           <div className="flex-1 space-y-1.5">

--- a/src/components/ui/MonthPicker.tsx
+++ b/src/components/ui/MonthPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type Ref } from 'react';
+import { useEffect, useRef, useState, type Ref, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { format } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
@@ -16,6 +16,8 @@ interface MonthPickerProps {
   /** 'month' → year + 12-month grid; 'day' → full calendar with days. */
   mode?: PickerMode;
   inputRef?: Ref<HTMLInputElement>;
+  /** Forwarded to the text input (e.g. Enter-to-save in custom modals). */
+  onKeyDown?: (e: ReactKeyboardEvent<HTMLInputElement>) => void;
 }
 
 const YM = /^(\d{4})-(\d{2})$/;
@@ -29,7 +31,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
  * day grid). Typing passes straight through, so the caller's validation still
  * runs on save.
  */
-export function MonthPicker({ id, value, onChange, placeholder, mode = 'month', inputRef }: MonthPickerProps) {
+export function MonthPicker({ id, value, onChange, placeholder, mode = 'month', inputRef, onKeyDown }: MonthPickerProps) {
   const { lang, t } = useFinance();
   const c = t.common;
   const locale = lang === 'nb' ? nb : enUS;
@@ -119,6 +121,7 @@ export function MonthPicker({ id, value, onChange, placeholder, mode = 'month', 
           inputMode="numeric"
           autoComplete="off"
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           // On blur, tidy common typing into canonical form (2022-7-15 →
           // 2022-07-15, 15.07.2022 → 2022-07-15). Leave genuinely unparseable
           // input untouched so the caller's save-time error can surface.

--- a/src/pages/LoanPage.tsx
+++ b/src/pages/LoanPage.tsx
@@ -167,7 +167,7 @@ const LoanPage: React.FC = () => {
   const editHomeownerMonth = (label: string, key: keyof HomeownerData, current: string) => {
     openModal({
       title: label,
-      fields: [{ key: 'value', label, type: 'month', value: current }],
+      fields: [{ key: 'value', label, type: 'monthpicker', pickerMode: 'month', value: current, placeholder: '2022-07' }],
       onSave: (vals) => {
         updateHomeowner(key, vals.value);
         closeModal();

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -413,8 +413,8 @@ const SalaryPage: React.FC = () => {
     const fields: ModalField[] = [
       { key: 'employer', label: t.salary.employer, type: 'text', value: existing?.employer ?? '', suggestions: employerSuggestions },
       { key: 'role', label: t.salary.role, type: 'text', value: existing?.role ?? '', suggestions: roleSuggestions },
-      { key: 'startDate', label: t.salary.startDate, type: 'text', value: existing?.startDate ?? '', placeholder: '2023-08' },
-      { key: 'endDate', label: t.salary.endDate, type: 'text', value: existing?.endDate ?? '', placeholder: '2024-09' },
+      { key: 'startDate', label: t.salary.startDate, type: 'monthpicker', pickerMode: 'month', value: existing?.startDate ?? '', placeholder: '2023-08' },
+      { key: 'endDate', label: t.salary.endDate, type: 'monthpicker', pickerMode: 'month', value: existing?.endDate ?? '', placeholder: '2024-09' },
       { key: 'contractedHoursPerWeek', label: t.salary.contractedHours, type: 'number', value: (existing?.contractedHoursPerWeek ?? 37.5).toString() },
       { key: 'onCallAnnual', label: t.salary.onCallAnnual, type: 'number', value: (existing?.onCallAnnual ?? '').toString(), placeholder: '0' },
     ];


### PR DESCRIPTION
Follow-up to #55 / #56. Rolls the calendar `MonthPicker` out to the remaining date fields so entry is consistent (typeable + calendar popover) everywhere.

## Why

#56 introduced the picker for the residence dates. The rest of the app still used plain text inputs (and one native month control) for dates, so behaviour was inconsistent.

## What

- **EditModal** now canonicalises any `monthpicker` field on submit (`2022-7-15` → `2022-07-15`, `15.07.2022` → `2022-07-15`), so each caller's existing validation sees a tidy value no matter how it was typed.
- **Month mode**: salary job start/end, salary-change effective date, hours period-month, goal deadline, student-loan interest-free-until, loan origination date, onboarding job start/end.
- **Day mode**: bonus and overtime dates.
- `MonthPicker` gains an optional `onKeyDown` passthrough so the custom `RecordEventModal` keeps Enter-to-save; that modal also normalises each date before validating.

PayslipImportModal's month field is intentionally left as a plain input — it sits in a dense batch-import grid where a per-row calendar popover doesn't fit.

## Verification

- `npx tsc -b`, `npm run lint`, `npm test` (679 pass) all clean.
- Rebuilt and checked in the app (demo + real data, nothing saved): the salary job editor shows month pickers for start/end, the record-event modal shows a month picker for salary/hours and a day picker for bonus/overtime, Escape closes only the popover, 0 console errors.