### PR TITLE
ci: build-only, let Kargo promote via homelab PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,17 +49,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      short_sha: ${{ steps.vars.outputs.short_sha }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      # 7-char short SHA, matching docker/metadata-action's type=sha,format=short.
-      - name: Compute short SHA
-        id: vars
-        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -83,6 +75,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short
+            # Monotonic SemVer tag the Kargo Warehouse selects (like portfolio/blog).
+            type=raw,value=0.0.${{ github.run_number }},enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -97,17 +91,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  # Open a homelab PR bumping the deployment image to the SHA we just pushed.
-  deploy:
-    name: Bump homelab image tag
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: mortennordbye/homelab/.github/workflows/bump-image.yml@main
-    with:
-      app_dir: k8s/talos/apps/headroom
-      image: ghcr.io/mortennordbye/headroom
-      new_tag: sha-${{ needs.build.outputs.short_sha }}
-    secrets:
-      app-id: ${{ secrets.HOMELAB_DEPLOYER_APP_ID }}
-      app-private-key: ${{ secrets.HOMELAB_DEPLOYER_PRIVATE_KEY }}


### PR DESCRIPTION
## Why

Move headroom onto the same Kargo promotion flow as portfolio/blog/logeverylift: CI builds and pushes the image, and Kargo (in the homelab repo) detects it and opens the deploy PR.

## What

- Add a `0.0.${{ github.run_number }}` tag (main only) so the homelab Kargo Warehouse can select it via SemVer. `sha-` and `latest` tags are unchanged.
- Remove the `deploy:` job that called `homelab/.github/workflows/bump-image.yml`.
- Remove the now-orphaned short-SHA step/output that only the deploy job used.

## Note

Pairs with the homelab PR that adds the `headroom-cd` Kargo project. Once both are in, a push to main builds a `0.0.<run>` image, Kargo opens a homelab PR, and merging it deploys and smoke-tests.