### PR TITLE
chore(ci): pin GitHub Actions to SHAs and add SECURITY.md report link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
           cache: npm
@@ -51,17 +51,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/mortennordbye/headroom
           tags: |
@@ -79,7 +79,7 @@ jobs:
             type=raw,value=0.0.${{ github.run_number }},enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -14,16 +14,16 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Build image
         run: docker build -t local-scan-image .
-      - uses: aquasecurity/trivy-action@v0.36.0
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: local-scan-image
           format: sarif
           output: trivy-results.sarif
           ignore-unfixed: true
           severity: CRITICAL,HIGH
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,5 +9,5 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/dependency-review-action@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,14 +15,14 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,8 @@ Only the latest release is actively supported with security updates.
 ## Reporting a Vulnerability
 
 Please do not report security vulnerabilities through public GitHub issues.
-Use the "Report a vulnerability" button under this repository's **Security** tab
-(private vulnerability reporting is enabled). You will receive an acknowledgement
+Report privately via GitHub Security Advisories:
+https://github.com/mortennordbye/headroom/security/advisories/new
+(the "Report a vulnerability" button under this repository's **Security** tab;
+private vulnerability reporting is enabled). You will receive an acknowledgement
 within 48 hours.


### PR DESCRIPTION
## Why

Raise the OpenSSF Scorecard score with the two changes that add no friction to pushing to main. Skips the branch-protection ruleset, which would gate direct pushes.

Current score 6.2/10. These target the two most fixable checks:
- Pinned-Dependencies (was 2/10): actions referenced by mutable tags.
- Security-Policy (was 4/10): SECURITY.md had no linked reporting content.

## What

- Pin every `uses:` across `build.yml`, `container-scan.yml`, `scorecard.yml`, and `dependency-review.yml` to a full 40-char commit SHA, with the version in a trailing comment. Dependabot's `github-actions` ecosystem is already configured, so the pins stay current automatically.
- Add an explicit GitHub Security Advisories URL to `SECURITY.md`.

No workflow structure, triggers, or permissions changed — only the ref portion of each `uses:` line.

## Verification

- `grep` confirms no remaining `@vX` tags in any workflow.
- Indentation and step structure unchanged; edits are ref-only substitutions.
- Scorecard will re-evaluate on its next scheduled run.