### PR TITLE
fix(docker): copy new server modules into image; pin base images by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       github-actions:
         patterns: ["*"]
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    groups:
+      docker:
+        patterns: ["*"]
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build frontend
-FROM node:22-slim AS frontend-build
+FROM node:22-slim@sha256:6c74791e557ce11fc957704f6d4fe134a7bc8d6f5ca4403205b2966bd488f6b3 AS frontend-build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: production
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 WORKDIR /app
 # su-exec lets the entrypoint drop from root to `node` after fixing volume perms.
 RUN apk add --no-cache su-exec
@@ -22,6 +22,11 @@ COPY server/index.js ./
 COPY server/auth.js ./
 COPY server/seed.js ./
 COPY server/ssb.js ./
+COPY server/boligPrices.js ./
+COPY server/norgesBank.js ./
+COPY server/postnummer.js ./
+# postnummer.js reads ./data/postnummer.tsv relative to its own dir (/app).
+COPY server/data ./data
 COPY server/bank.js ./
 COPY server/backup.js ./
 COPY server/docker-entrypoint.sh ./


### PR DESCRIPTION
## Why

The merged SSB/Norges Bank feature broke the production Docker image. The Dockerfile copies server files one by one, and the three new modules plus their data file were never added, so the container crashes at startup:

```
Error: Cannot find module './boligPrices'
    at Object.<anonymous> (/app/index.js:8:47)
```

## What

- Add the missing `COPY` lines for `boligPrices.js`, `norgesBank.js`, `postnummer.js`, and `server/data` (the postnummer register that `postnummer.js` reads at runtime relative to `/app`).
- Pin both node base images (`22-slim`, `22-alpine`) to their multi-arch index digests, resolved with `docker buildx imagetools inspect` (Pinned-Dependencies check → 8/10 to 10/10).
- Add a `docker` ecosystem to `dependabot.yml` so the pinned digests keep receiving weekly security bumps, same as the actions.

No changes that gate pushing to main.

## Verification

`docker build` + `docker run` against a throwaway volume:
- Container starts clean — no `MODULE_NOT_FOUND`; log shows `API running on :3001`.
- `/healthz` 200.
- `/api/kvmpris?postnr=0575&type=leilighet` returns region 0301 / Oslo / 102372 kr/m2 (proves boligPrices.js + postnummer.tsv are in the image).
- `/api/policyrate` returns 4.25 (proves norgesBank.js is in the image).