### PR TITLE
test(fuzz): add fast-check property tests for the money math

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "headroom",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "headroom",
-      "version": "0.0.0",
+      "version": "3.0.0",
       "dependencies": {
         "@fontsource/cormorant-garamond": "^5.2.11",
         "@fontsource/ibm-plex-mono": "^5.2.7",
@@ -30,6 +30,7 @@
         "eslint": "^10.6.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fast-check": "^4.9.0",
         "globals": "^17.7.0",
         "postcss": "^8.5.16",
         "tailwindcss": "^4.2.2",
@@ -5572,6 +5573,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7472,6 +7496,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^10.6.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fast-check": "^4.9.0",
     "globals": "^17.7.0",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.2.2",

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -3,7 +3,11 @@ export function calcMonthlyPayment(principal: number, annualRate: number, years:
   const n = years * 12;
   if (n <= 0) return 0; // guard: a 0/negative term has no payment schedule (avoids Infinity/NaN)
   if (monthlyRate === 0) return principal / n;
-  return principal * monthlyRate / (1 - Math.pow(1 + monthlyRate, -n));
+  const payment = principal * monthlyRate / (1 - Math.pow(1 + monthlyRate, -n));
+  // A subnormal rate can round (1 + monthlyRate) back to 1, underflowing the
+  // denominator to 0 (→ NaN/Infinity). At that point the loan is effectively
+  // interest-free, so fall back to the straight-line payment.
+  return Number.isFinite(payment) ? payment : principal / n;
 }
 
 // Norwegian mortgage-lending limits (utlånsforskriften):

--- a/src/lib/moneyMath.property.test.ts
+++ b/src/lib/moneyMath.property.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { calcMonthlyPayment } from './calculations';
+import { calcNorwegianTax } from './norwegianTax';
+import { parseLocaleNumber } from './validators';
+import { estimatedPropertyValue } from './propertyEstimate';
+
+// Property-based ("fuzz") tests for the money-math core. Each throws thousands of
+// random inputs at a pure function and asserts an invariant, targeting this app's
+// highest-risk bug class: NaN/Infinity leaking into arithmetic and charts.
+
+describe('calcMonthlyPayment (property)', () => {
+  // principal + rate stay fully adversarial doubles (a subnormal rate exercises
+  // the denominator-underflow guard); the term is fuzzed as an integer, its real
+  // domain (nedbetalingstid is always a whole number of years).
+  it('returns a finite, non-negative payment for any realistic loan', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1e12, noNaN: true, noDefaultInfinity: true }),
+        fc.double({ min: 0, max: 1e6, noNaN: true, noDefaultInfinity: true }),
+        fc.integer({ min: 0, max: 40 }),
+        (principal, rate, years) => {
+          const p = calcMonthlyPayment(principal, rate, years);
+          expect(Number.isFinite(p)).toBe(true);
+          expect(p).toBeGreaterThanOrEqual(0);
+        },
+      ),
+    );
+  });
+
+  it('never exceeds the principal in a single monthly payment for terms >= 1 year', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 1, max: 1e12, noNaN: true, noDefaultInfinity: true }),
+        fc.double({ min: 0, max: 30, noNaN: true, noDefaultInfinity: true }),
+        fc.integer({ min: 1, max: 40 }),
+        (principal, rate, years) => {
+          expect(calcMonthlyPayment(principal, rate, years)).toBeLessThanOrEqual(principal);
+        },
+      ),
+    );
+  });
+});
+
+describe('calcNorwegianTax (property)', () => {
+  it('keeps tax finite and within 0..gross for any income (incl. negatives)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1e7, max: 1e8, noNaN: true, noDefaultInfinity: true }),
+        fc.double({ min: 0, max: 1e5, noNaN: true, noDefaultInfinity: true }),
+        (gross, ips) => {
+          const t = calcNorwegianTax(gross, ips);
+          const clampedGross = Math.max(0, gross);
+          expect(Number.isFinite(t.totalTax)).toBe(true);
+          expect(t.totalTax).toBeGreaterThanOrEqual(0);
+          // You never owe more income tax than you earned.
+          expect(t.totalTax).toBeLessThanOrEqual(clampedGross + 1e-6);
+          expect(t.effectiveRatePct).toBeGreaterThanOrEqual(0);
+          expect(t.effectiveRatePct).toBeLessThanOrEqual(100);
+          expect(Number.isFinite(t.netMonthly)).toBe(true);
+        },
+      ),
+    );
+  });
+});
+
+describe('parseLocaleNumber (property)', () => {
+  it('never throws and returns NaN or a number for any string', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        const n = parseLocaleNumber(s);
+        expect(typeof n).toBe('number');
+      }),
+    );
+  });
+
+  it('round-trips a finite number through its string form (comma or dot)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: -1e6, max: 1e6, noNaN: true, noDefaultInfinity: true }),
+        (n) => {
+          const rounded = Math.round(n * 100) / 100; // 2-decimal money value
+          const dot = parseLocaleNumber(String(rounded));
+          const comma = parseLocaleNumber(String(rounded).replace('.', ','));
+          expect(dot).toBeCloseTo(rounded, 6);
+          expect(comma).toBeCloseTo(rounded, 6);
+        },
+      ),
+    );
+  });
+});
+
+describe('estimatedPropertyValue (property)', () => {
+  it('never yields NaN — returns null or a finite positive value for any inputs', () => {
+    // fc.double() here intentionally includes NaN and +/-Infinity as adversarial inputs.
+    fc.assert(
+      fc.property(fc.double(), fc.double(), (sqm, price) => {
+        const v = estimatedPropertyValue(sqm, price);
+        if (v !== null) {
+          expect(Number.isFinite(v)).toBe(true);
+          expect(v).toBeGreaterThan(0);
+        }
+      }),
+    );
+  });
+});

--- a/src/lib/propertyEstimate.ts
+++ b/src/lib/propertyEstimate.ts
@@ -9,5 +9,8 @@ export function estimatedPropertyValue(
 ): number | null {
   if (!sizeSqm || sizeSqm <= 0) return null;
   if (pricePerSqm == null || !(pricePerSqm > 0)) return null;
-  return Math.round(sizeSqm * pricePerSqm);
+  const value = Math.round(sizeSqm * pricePerSqm);
+  // Guard the product too: it can overflow to Infinity or underflow to 0 at
+  // extreme magnitudes. An estimate is only meaningful when finite and positive.
+  return Number.isFinite(value) && value > 0 ? value : null;
 }


### PR DESCRIPTION
## Why

Adds property-based ("fuzz") testing with fast-check. OpenSSF Scorecard recognises fast-check for its Fuzzing check (currently 0/10), so this lifts that check without any new CI job or push-gating. More importantly, it directly targets the app's stated highest-risk bug class: NaN/Infinity leaking into arithmetic and rendering in a chart.

## What

New `src/lib/moneyMath.property.test.ts` throws thousands of random inputs at the pure calc core and asserts invariants, running inside the existing Vitest suite:
- `calcMonthlyPayment` stays finite and non-negative, and never exceeds the principal in a single month for terms >= 1 year.
- `calcNorwegianTax` keeps total tax finite and within `0..gross`, effective rate within `0..100`, for any income including negatives.
- `parseLocaleNumber` never throws and round-trips a finite number through both comma and dot forms.
- `estimatedPropertyValue` never yields NaN.

The fuzzer immediately found two real edge cases in subnormal-double arithmetic, both fixed:
- `calcMonthlyPayment` could underflow the annuity denominator to 0 for a subnormal rate, producing `NaN`/`Infinity`. It now falls back to the interest-free straight-line payment when the computed value is non-finite.
- `estimatedPropertyValue` could round a tiny product to `0` or overflow to `Infinity`. It now returns `null` unless the value is finite and positive.

Loan term is fuzzed as an integer (its real domain — nedbetalingstid is whole years), while principal and rate stay fully adversarial doubles.

## Verification

`tsc` + `eslint` clean; full Vitest suite green (706 tests, +6). The two function changes touch only previously-non-finite outputs, so existing calc tests are unaffected.