### PR TITLE
chore: auto-merge non-major Dependabot PRs and group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    open-pull-requests-limit: 5
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+      # Without this, security updates ignore groups entirely and arrive as one
+      # PR per package.
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/server"
@@ -36,6 +42,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    open-pull-requests-limit: 5
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+# Needed so `gh pr merge --auto` can arm auto-merge on the PR. GitHub grants
+# these to the Dependabot-triggered token only because they are requested here.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Majors stay manual. For a grouped PR, update-type is the largest bump in
+      # the group, so one major keeps the whole batch out of auto-merge.
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

Ten Dependabot PRs were open at once, all needing a manual merge. Two things caused the pile-up:

- Nothing auto-merges. Every routine patch bump waits on a human.
- Security updates ignore `groups` unless a group opts in with `applies-to: security-updates`, so they arrived one PR per package (#86 fast-uri, #89 postcss) instead of batching.

## What

- `.github/workflows/dependabot-auto-merge.yml` — reads `dependabot/fetch-metadata` and arms GitHub auto-merge when the update type is not `semver-major`. For grouped PRs the metadata reports the largest bump in the group, so one major keeps the whole batch manual.
- `.github/dependabot.yml` — adds an `npm-security` group with `applies-to: security-updates` for both `/` and `/server`, plus `open-pull-requests-limit: 5`.

Auto-merge only fires once the required status checks pass, so a broken build or a `dependency-review` advisory hit still holds the PR open.

## Verification

- `npx tsc -b && npm run lint && npm test` pass on this branch (YAML-only change; run to confirm the four dependency bumps merged ahead of it left main healthy).
- The workflow itself is exercised by the next Dependabot PR. Behaviour is observable there: a patch/minor PR should show "auto-merge enabled" immediately after CI starts.

Requires the `protect-default-branch` ruleset to carry required status checks (`Typecheck, lint & test`, `dependency-review`, `Build linux/amd64`, `Build linux/arm64`) — without them GitHub has nothing to gate auto-merge on and refuses to arm it. Applied separately via the API.
