### PR TITLE
chore(deps): upgrade react-router-dom 7 to react-router 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "date-fns": "^4.1.0",
         "lucide-react": "^1.23.0",
         "pdfjs-dist": "^4.10.38",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router-dom": "^7.18.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "recharts": "^3.9.2"
       },
       "devDependencies": {
@@ -4932,18 +4932,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -8271,41 +8264,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/recharts": {
@@ -8722,12 +8698,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^1.23.0",
     "pdfjs-dist": "^4.10.38",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-router-dom": "^7.18.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0",
     "recharts": "^3.9.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
 import { FinanceProvider, useFinance, useFinanceSettings } from './context/FinanceContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import UpdatePrompt from './components/UpdatePrompt';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { NavLink, Outlet, useLocation, useSearchParams } from 'react-router-dom';
+import { NavLink, Outlet, useLocation, useSearchParams } from 'react-router';
 import {
   ChevronLeft,
   ChevronRight,

--- a/src/components/ResidenceHistory.tsx
+++ b/src/components/ResidenceHistory.tsx
@@ -1,5 +1,5 @@
 import { useState, createElement } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { format, parse } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { Home, Plus, Edit2, Trash2, Clock, Building2, Building, Warehouse, TreePine, MapPin, type LucideIcon } from 'lucide-react';

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback, type ReactNode } from 'react';
 import ReactDOM from 'react-dom';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { format } from 'date-fns';
 import {
   ArrowLeft, ArrowRight, Check, X, Sparkles, Plus, FileUp, ChevronDown,

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 // One pill-segmented control for the whole app. Two rendering modes, same look:
 //  • button mode  — in-page pick-one state (Bolig hub/mode, Settings currency).

--- a/src/pages/BudgetPage.tsx
+++ b/src/pages/BudgetPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect, lazy, Suspense } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   PlusCircle,
   Trash2,

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,7 +3,7 @@ import {
   TrendingUp, Wallet, Home, Zap, PiggyBank, BarChart2, Bitcoin, Shield, Receipt,
   ArrowUpRight, BarChart3, LifeBuoy, Scale, Pencil, AlertTriangle, X,
 } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { format, parse, format as fmtDate, subMonths } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinance, DEFAULT_GROWTH_RATES, DEFAULT_TAX_RATES, type DailyTransaction } from '../context/FinanceContext';


### PR DESCRIPTION
## Why

`react-router@7.x` is covered by [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) (high, RSC-mode CSRF bypass). The vulnerable range is `>= 7.12.0, < 8.3.0` — the whole 7 line, with the fix only in 8.3.0.

Headroom does not use RSC mode, so this is not exploitable here. It still matters because `dependency-review` fails on any PR that moves react-router in the lockfile. That is what blocks #88 (the 19-package minor/patch group), and it would block every future group PR that touches the router.

## What

- `react-router-dom@^7.18.1` → `react-router@^8.3.0`. v8 removes the `react-router-dom` package entirely; the DOM exports were folded into `react-router`.
- Seven import specifiers updated. No other change — `BrowserRouter`, `Routes`, `Route`, `Navigate`, `Link`, `NavLink`, `Outlet`, `useLocation`, `useNavigate`, and `useSearchParams` are all unchanged in v8.
- React floor raised `^19.2.4` → `^19.2.7` to match react-router 8's peer requirement. Installs already resolved to 19.2.7, so nothing moves.

Other v8 requirements were already met: Vite 8.1.3 (needs 7+), ESM-only (`"type": "module"`), Node 22 in CI and the Docker image (needs 22.22.0+).

## Verification

- `npx tsc -b && npm run lint && npm test` — clean, 930 tests across 77 files pass.
- `npm run build` — production bundle builds, PWA precache regenerated.
- `make build`, then smoke-tested the running container:
  - `/`, `/budget`, `/forecast`, `/settings` all render; nav links do client-side transitions.
  - `useSearchParams` still writes the month key (`/budget?m=2026-08`).
  - Legacy redirects intact: `/loan` → `/bolig`, `/overview` → `/`.
  - 0 console errors and 0 warnings.

Unrelated pre-existing note: there is no catch-all `*` route, so an unknown path renders a blank page. Unchanged by this PR, not fixed here.
