### PR TITLE
feat: public read-only demo mode (DEMO_MODE)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -589,3 +589,25 @@ they are worth closing out rather than leaving to rot.
   current lint stack. Nothing to fix in this repo. **What would unblock**: a `typescript-eslint`
   release widening its peer range to TS 7; then the bump is mechanical. **Where**:
   `package.json` (`typescript`, `typescript-eslint`); open PR #27.
+
+## Public demo mode (2026-08) — deferred items
+
+`DEMO_MODE=1` shipped (`server/demo.js`, plus the locked client demo in `FinanceContext`).
+Two gaps were knowingly left.
+
+- **The rate limiter is one global bucket, which a public demo shares across all visitors.**
+  `apiLimiter` uses `keyGenerator: () => 'single-user'` — deliberately, because the app is
+  single-user and that sidesteps `X-Forwarded-For` trust. On the public demo that means one
+  visitor (or one crawler) hammering `/api/inflation` can spend the 2000-per-15-min budget and
+  429 everyone else. Deferred because per-IP keying requires deciding how far to trust the
+  proxy chain, and it would change limiter behaviour for the private instance too, which was
+  out of scope for standing the demo up. The blast radius is availability of a demo, not data.
+  **What would unblock**: key the limiter per-IP when `DEMO_MODE` is on, with `app.set('trust proxy', …)`
+  scoped to the known gateway. **Where**: `server/index.js` (`globalKey`, `apiLimiter`).
+- **A visitor holding a stale service worker would boot the pre-demo client.** The PWA precaches
+  the app shell, so a browser that cached a build predating `DEMO_MODE` would fetch `/api/data`,
+  find it empty, and then 403 on every autosave — an empty app with a "not saved" banner rather
+  than the demo. Deferred because it cannot happen on a fresh deployment (no prior visitors) and
+  self-heals as soon as the update prompt is accepted. **What would unblock**: nothing needed
+  unless the demo URL is ever repointed at a different app; if so, bump the SW cache name.
+  **Where**: `vite.config.ts` (VitePWA `workbox`), `src/context/FinanceContext.tsx` (boot effect).

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN --mount=type=cache,target=/root/.npm \
   && apk del .build-deps
 COPY server/index.js ./
 COPY server/auth.js ./
+COPY server/demo.js ./
 COPY server/seed.js ./
 COPY server/ssb.js ./
 COPY server/boligPrices.js ./

--- a/README.md
+++ b/README.md
@@ -198,6 +198,43 @@ All optional — the defaults are sensible and nothing needs to be set.
 | `PORT` | `3001` | Port the server listens on inside the container. |
 | `ALLOWED_HOSTS` | _(unset — all hosts allowed)_ | Comma-separated hostname allowlist, e.g. `finance.example.com,localhost`. When unset, no host filtering is applied. |
 | `AUTH_PASSWORD` | _(unset — auth off)_ | When set, forces the [optional password](#optional-password) on with this password, overriding the in-app Settings toggle. |
+| `DEMO_MODE` | _(unset — off)_ | Set to `1` to run this instance as a [public read-only demo](#public-demo-mode). |
+
+## Public demo mode
+
+`DEMO_MODE=1` turns an instance into a public showcase — something you can link
+from a blog post and let strangers click through, without them reaching any real
+data or leaving anything behind.
+
+What changes:
+
+- **The API is closed to writes.** Every non-GET request under `/api/` is refused
+  with `403`, and the whole `/api/bank/*` namespace is refused outright (its GETs
+  aren't safe reads — one proxies to Enable Banking on the instance's own
+  credentials, another completes a bank link). This is enforced server-side in
+  `server/demo.js`, so it holds no matter what a client sends.
+- **Each visitor gets their own sandbox.** The app detects demo mode at boot (via
+  `GET /api/config`) and fills itself with the fictional dataset in
+  `src/lib/demoData.ts`, generated in the browser. It never fetches or posts
+  `/api/data`. Visitors can edit anything; their changes stay in their own tab and
+  disappear on reload. No visitor can affect what another sees.
+- **The UI drops what doesn't apply.** No exit-demo button (there is no real data
+  behind it), no password settings, no restore points, no SQLite-backup restore,
+  no "delete all data". A "Reset sample data" button puts the dataset back.
+- **No background jobs.** Rotating backups and scheduled bank sync are both
+  skipped — a demo instance has nothing worth backing up and no bank to sync.
+
+A demo instance needs no persistent volume; give it ephemeral storage and no bank
+credentials. Run it as a **separate instance** from your real one — `DEMO_MODE`
+protects the API, but pointing it at your own data volume still serves that data
+to the internet on `GET /api/data`.
+
+```yaml
+# docker-compose snippet for a demo instance
+environment:
+  DEMO_MODE: "1"
+  ALLOWED_HOSTS: "demo.example.com"
+```
 
 ## Data persistence
 

--- a/server/demo.js
+++ b/server/demo.js
@@ -1,0 +1,45 @@
+// Public read-only demo mode (DEMO_MODE=1).
+//
+// A demo instance is meant to be reachable from the open internet, so unlike the
+// normal single-user deployment it cannot assume the caller is the owner. The
+// API is therefore closed by default and only safe reads get through — the
+// client-side demo dataset lives in the browser (src/lib/demoData.ts), so a
+// visitor's edits never need to reach the server at all.
+//
+// Pure, dependency-free helpers (no Express, no SQLite) so the gate is unit
+// testable without booting the app; index.js holds only the wiring.
+
+const DEMO_ERROR = 'this is a public read-only demo — changes are not saved';
+
+/** Is DEMO_MODE switched on in this environment? */
+function isDemoMode(env) {
+  return /^(1|true|yes|on)$/i.test(String((env && env.DEMO_MODE) || '').trim());
+}
+
+/**
+ * Build the `/api/*` demo gate middleware. Deny-by-default: every mutation is
+ * refused, and the bank namespace is refused outright because its GETs are not
+ * safe reads — `/api/bank/aspsps` proxies to Enable Banking on the app's own
+ * credentials (someone else's quota and money) and `/api/bank/callback`
+ * completes a bank link as a side effect of a GET.
+ *
+ * The path is lowercased before every comparison because Express matches routes
+ * case-insensitively: without it, `/API/data` would slip past the gate and still
+ * reach the `/api/data` handler.
+ */
+function makeDemoGate() {
+  return (req, res, next) => {
+    const path = (req.path || '').toLowerCase();
+    if (!path.startsWith('/api/')) return next(); // static assets + SPA shell
+    // Prefix (not `/api/bank/`) so a future bare `/api/bank` route is covered
+    // too. Over-blocking is the safe direction here.
+    if (path.startsWith('/api/bank')) {
+      return res.status(403).json({ error: DEMO_ERROR });
+    }
+    const method = (req.method || '').toUpperCase();
+    if (method === 'GET' || method === 'HEAD') return next();
+    return res.status(403).json({ error: DEMO_ERROR });
+  };
+}
+
+module.exports = { DEMO_ERROR, isDemoMode, makeDemoGate };

--- a/server/demo.test.js
+++ b/server/demo.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DEMO_ERROR, isDemoMode, makeDemoGate } from './demo.js';
+
+describe('isDemoMode', () => {
+  it('is on for the documented truthy spellings', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', ' 1 ']) {
+      expect(isDemoMode({ DEMO_MODE: v })).toBe(true);
+    }
+  });
+
+  it('is off when unset, empty or falsy', () => {
+    for (const env of [undefined, {}, { DEMO_MODE: '' }, { DEMO_MODE: '0' }, { DEMO_MODE: 'false' }, { DEMO_MODE: 'no' }]) {
+      expect(isDemoMode(env)).toBe(false);
+    }
+  });
+});
+
+describe('makeDemoGate', () => {
+  // Minimal Express-shaped doubles: the gate only reads path/method and either
+  // calls next() or answers with a status + json body.
+  const run = (method, path) => {
+    const res = { status: vi.fn(() => res), json: vi.fn(() => res) };
+    const next = vi.fn();
+    makeDemoGate()({ method, path }, res, next);
+    return { res, next, passed: next.mock.calls.length > 0 };
+  };
+  const expectRefused = (r) => {
+    expect(r.passed).toBe(false);
+    expect(r.res.status).toHaveBeenCalledWith(403);
+    expect(r.res.json).toHaveBeenCalledWith({ error: DEMO_ERROR });
+  };
+
+  it('lets safe API reads through', () => {
+    expect(run('GET', '/api/data').passed).toBe(true);
+    expect(run('GET', '/api/history').passed).toBe(true);
+    expect(run('GET', '/api/inflation').passed).toBe(true);
+    expect(run('GET', '/api/config').passed).toBe(true);
+    expect(run('HEAD', '/api/data').passed).toBe(true);
+  });
+
+  it('refuses every API mutation', () => {
+    for (const [m, p] of [
+      ['POST', '/api/data'],
+      ['POST', '/api/restore'],
+      ['POST', '/api/history/3/restore'],
+      ['POST', '/api/auth/config'],
+      ['POST', '/api/auth/login'],
+      ['PUT', '/api/data'],
+      ['PATCH', '/api/data'],
+      ['DELETE', '/api/data'],
+    ]) {
+      expectRefused(run(m, p));
+    }
+  });
+
+  it('refuses the whole bank namespace, reads included', () => {
+    // These GETs are not safe reads: aspsps proxies to Enable Banking on the
+    // app's credentials, and callback completes a link as a side effect.
+    expectRefused(run('GET', '/api/bank/status'));
+    expectRefused(run('GET', '/api/bank/aspsps'));
+    expectRefused(run('GET', '/api/bank/callback'));
+    expectRefused(run('POST', '/api/bank/sync'));
+    expectRefused(run('DELETE', '/api/bank/connection/abc'));
+  });
+
+  it('is not fooled by path casing (Express matches routes case-insensitively)', () => {
+    expectRefused(run('POST', '/API/DATA'));
+    expectRefused(run('GET', '/API/Bank/Aspsps'));
+  });
+
+  it('leaves static assets and the SPA shell alone', () => {
+    expect(run('GET', '/').passed).toBe(true);
+    expect(run('GET', '/settings').passed).toBe(true);
+    expect(run('GET', '/static/index-abc123.js').passed).toBe(true);
+    expect(run('GET', '/healthz').passed).toBe(true);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,12 @@ const bank = require('./bank');
 const { startBackupSchedule, parseCount } = require('./backup');
 const { startBankSyncSchedule } = require('./bankSync');
 const { resolveAuth, hashPassword, createSessionStore, parseCookies, serializeCookie, makeAuthGate } = require('./auth');
+const { isDemoMode, makeDemoGate } = require('./demo');
 const pkg = require('./package.json');
+
+// Public read-only demo instance (see server/demo.js). Off unless DEMO_MODE is
+// set, so a normal deployment is untouched.
+const DEMO_MODE = isDemoMode(process.env);
 
 // Build identity. CI passes the commit SHA as BUILD_SHA (see Dockerfile / the
 // build workflow's build-args); local runs report 'dev'. Together with the
@@ -218,10 +223,18 @@ const sessionToken = (req) => parseCookies(req.headers.cookie)[SESSION_COOKIE];
 // served plain-HTTP behind a TLS-terminating proxy).
 const cookieSecure = (req) => (req.headers['x-forwarded-proto'] || '').split(',')[0].trim() === 'https';
 
+// Close the API down to safe reads on a public demo instance. Mounted BEFORE the
+// auth gate so the demo is read-only regardless of whether auth is configured —
+// this is the security boundary; the client's demo mode is only presentation.
+if (DEMO_MODE) {
+  console.log('[demo] DEMO_MODE is on — the API is read-only and bank routes are closed');
+  app.use(makeDemoGate());
+}
+
 // Gate /api/* when auth is on. Static assets and the SPA shell stay public (they
 // hold no personal data — the login screen renders from them); health, version
 // and the auth endpoints themselves are exempt so login can happen.
-const AUTH_EXEMPT = ['/healthz', '/api/version', '/api/auth/status', '/api/auth/login', '/api/auth/logout'];
+const AUTH_EXEMPT = ['/healthz', '/api/version', '/api/config', '/api/auth/status', '/api/auth/login', '/api/auth/logout'];
 app.use(makeAuthGate({
   exempt: AUTH_EXEMPT,
   currentAuth,
@@ -413,6 +426,13 @@ app.get('/healthz', (_req, res) => {
 // sha is the CI-stamped commit ('dev' locally).
 app.get('/api/version', (_req, res) => {
   res.json({ version: pkg.version, sha: BUILD_SHA });
+});
+
+// Server-side switches the client needs before it decides how to boot. Fetched
+// first (ahead of /api/data) so a demo instance can send the visitor straight
+// into demo mode instead of loading — and then failing to save — real data.
+app.get('/api/config', (_req, res) => {
+  res.json({ demoMode: DEMO_MODE });
 });
 
 app.get('/api/data', (req, res) => {
@@ -982,22 +1002,28 @@ if (fs.existsSync(DIST)) {
 // When required (integration tests import the app for supertest), skip both so
 // no port is bound and no backup timer/files are created.
 if (require.main === module) {
-  // Rotating on-disk backups (see backup.js). BACKUP_INTERVAL_HOURS=0 disables it.
-  const backupSchedule = startBackupSchedule(db, DATA_DIR, {
-    intervalHours: parseCount(process.env.BACKUP_INTERVAL_HOURS, 24),
-    keep: parseCount(process.env.BACKUP_KEEP, 7),
-  });
-  if (backupSchedule) console.log(`[backup] rotating snapshots enabled → ${backupSchedule.dir}`);
+  // Both schedules are pointless on a demo instance — its volume is ephemeral
+  // and holds no real data, and it has no bank credentials to sync with.
+  // BACKUP_INTERVAL_HOURS=0 / BANK_SYNC_INTERVAL_HOURS=0 have the same effect;
+  // forcing them here means the demo can't be misconfigured into doing either.
+  if (!DEMO_MODE) {
+    // Rotating on-disk backups (see backup.js). BACKUP_INTERVAL_HOURS=0 disables it.
+    const backupSchedule = startBackupSchedule(db, DATA_DIR, {
+      intervalHours: parseCount(process.env.BACKUP_INTERVAL_HOURS, 24),
+      keep: parseCount(process.env.BACKUP_KEEP, 7),
+    });
+    if (backupSchedule) console.log(`[backup] rotating snapshots enabled → ${backupSchedule.dir}`);
 
-  // Optional in-process bank sync (see bankSync.js). BANK_SYNC_INTERVAL_HOURS=0
-  // (default) disables it; the manual "Sync now" button and any external cron
-  // still work regardless.
-  const bankSyncSchedule = startBankSyncSchedule({
-    intervalHours: parseCount(process.env.BANK_SYNC_INTERVAL_HOURS, 0),
-    runSync: runBankSync,
-    lastSyncAgeMs: bank.lastSyncAgeMs,
-  });
-  if (bankSyncSchedule) console.log(`[bank] scheduled sync enabled → every ${bankSyncSchedule.intervalHours}h`);
+    // Optional in-process bank sync (see bankSync.js). BANK_SYNC_INTERVAL_HOURS=0
+    // (default) disables it; the manual "Sync now" button and any external cron
+    // still work regardless.
+    const bankSyncSchedule = startBankSyncSchedule({
+      intervalHours: parseCount(process.env.BANK_SYNC_INTERVAL_HOURS, 0),
+      runSync: runBankSync,
+      lastSyncAgeMs: bank.lastSyncAgeMs,
+    });
+    if (bankSyncSchedule) console.log(`[bank] scheduled sync enabled → every ${bankSyncSchedule.intervalHours}h`);
+  }
 
   const PORT = process.env.PORT || 3001;
   app.listen(PORT, () => console.log(`API running on :${PORT}`));

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -36,7 +36,7 @@ const BALANCE_SCOPED_ROUTES = ['/assets', '/bolig', '/pension'];
 const HIDE_TIME_MARKER_ROUTES = ['/settings', '/year'];
 
 const Layout: React.FC = () => {
-  const { t, lang, currentMonth, setCurrentMonth, dataLoadFailed, saveFailed, justSaved, retrySave, dataReloaded, dismissDataReloaded, hiddenNavItems, demoMode, toggleDemoMode, startOnboarding } = useFinanceSettings();
+  const { t, lang, currentMonth, setCurrentMonth, dataLoadFailed, saveFailed, justSaved, retrySave, dataReloaded, dismissDataReloaded, hiddenNavItems, demoMode, toggleDemoMode, demoLocked, startOnboarding } = useFinanceSettings();
   const hist = useBalanceHistory();
   const dateLocale = lang === 'nb' ? nb : enUS;
   const location = useLocation();
@@ -311,14 +311,19 @@ const Layout: React.FC = () => {
             style={{ background: 'var(--violet-bg)', borderColor: 'color-mix(in srgb, var(--violet) 35%, transparent)', color: 'var(--violet)' }}
             role="status"
           >
-            <span className="font-medium">{t.settings.demoBanner}</span>
-            <button
-              onClick={toggleDemoMode}
-              className="shrink-0 px-3 h-8 rounded-[6px] text-[12px] font-semibold"
-              style={{ background: 'var(--violet)', color: 'var(--bg-page)' }}
-            >
-              {t.settings.demoExit}
-            </button>
+            <span className="font-medium">
+              {demoLocked ? t.settings.demoPublicBanner : t.settings.demoBanner}
+            </span>
+            {/* No exit on a public demo — there is no real data behind it. */}
+            {!demoLocked && (
+              <button
+                onClick={toggleDemoMode}
+                className="shrink-0 px-3 h-8 rounded-[6px] text-[12px] font-semibold"
+                style={{ background: 'var(--violet)', color: 'var(--bg-page)' }}
+              >
+                {t.settings.demoExit}
+              </button>
+            )}
           </div>
         )}
         {dataLoadFailed && (

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -640,6 +640,14 @@ interface FinanceSettingsContextType {
   restoreCustomTaxRateDefault: () => void;
   demoMode: boolean;
   toggleDemoMode: () => void;
+  /** True on a public demo instance (server DEMO_MODE): demo mode is permanent —
+   *  there is no real data behind it to go back to, and the server refuses every
+   *  write. The UI hides anything that would exit demo mode, expose the owner's
+   *  deployment, or fail against a read-only API. */
+  demoLocked: boolean;
+  /** Put the demo dataset back the way it started, after a visitor has clicked
+   *  around and changed things. Only meaningful while `demoLocked`. */
+  resetDemo: () => void;
   /** First-run guided setup. `onboardingCompleted` persists; `onboardingActive`
    *  drives the tour overlay. `startOnboarding` opens it (Settings "replay"),
    *  `completeOnboarding` marks it done and closes it. */
@@ -1100,6 +1108,11 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   const [dismissedRecurringSuggestions, setDismissedRecurringSuggestions] = useState<string[]>([]);
   const [transferHintDismissed, setTransferHintDismissed] = useState(false);
   const [demoMode, setDemoMode] = useState(false);
+  // Public demo instance (server DEMO_MODE, read at boot from /api/config). Demo
+  // mode is then permanent: there is no real data to restore and every write is
+  // refused server-side, so the exit affordances are hidden rather than shown
+  // and left to fail.
+  const [demoLocked, setDemoLocked] = useState(false);
   // First-run guided setup. `onboardingCompleted` is the persisted flag;
   // `onboardingActive` (not persisted) is whether the tour overlay is showing.
   const [onboardingCompleted, setOnboardingCompleted] = useState(false);
@@ -1231,6 +1244,23 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     const ATTEMPTS = 3;
 
+    // A public demo instance never touches /api/data: the dataset is generated
+    // in the browser, so each visitor gets their own sandbox and their edits
+    // stay local. `loaded.current` deliberately stays false, which — alongside
+    // the `demoMode` guard — means the autosave path can never fire, and the
+    // server refuses writes anyway. Ordered before the data load so a demo
+    // visitor never sees an empty app flash into demo data.
+    const bootDemo = async () => {
+      const cfg = await fetch('/api/config')
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null);
+      if (cancelled || !cfg?.demoMode) return false;
+      setDemoLocked(true);
+      setDemoMode(true);
+      applyPayload(getDemoData(), false);
+      return true;
+    };
+
     // Retry the initial load a few times: a transient miss (e.g. a network
     // hiccup around service-worker activation) otherwise leaves the app showing
     // empty defaults until a manual refresh. Crucially, `loaded.current` is set
@@ -1270,7 +1300,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
       if (!cancelled) setDataLoadFailed(true);
     };
 
-    load();
+    void bootDemo().then((isDemo) => { if (!isDemo && !cancelled) void load(); });
     return () => { cancelled = true; };
   }, [applyPayload]);
 
@@ -2433,9 +2463,22 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   }, [demoMode, importAll]);
 
   const toggleDemoMode = useCallback(() => {
+    // On a public demo there is nothing to toggle back to: no snapshot was taken
+    // and the server holds no real data. Ignore rather than drop the visitor
+    // into an empty app.
+    if (demoLocked) return;
     if (demoMode) disableDemoMode();
     else enableDemoMode();
-  }, [demoMode, disableDemoMode, enableDemoMode]);
+  }, [demoLocked, demoMode, disableDemoMode, enableDemoMode]);
+
+  // Re-apply the pristine demo dataset. `resetMissing: false` (the same overlay
+  // the demo boots with) is a complete data reset in practice: getDemoData sets
+  // every field that can hold data, so each is overwritten wholesale. What it
+  // deliberately omits — language, currency, region, nav visibility — is exactly
+  // what the visitor should keep across a reset.
+  const resetDemo = useCallback(() => {
+    applyPayload(getDemoData(), false);
+  }, [applyPayload]);
 
   const resetAll = useCallback(() => {
     setIncome(0);
@@ -2614,7 +2657,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     payday, setPayday,
     formatCurrency, formatCurrencyShort,
     restoreGrowthRateDefaults, restoreCustomTaxRateDefault,
-    demoMode, toggleDemoMode,
+    demoMode, toggleDemoMode, demoLocked, resetDemo,
     onboardingCompleted, onboardingActive, onboardingEntry, onboardingNonce,
     startOnboarding, resetGuide, completeOnboarding,
     dataLoadFailed, authRequired, authEnabled, authSource, login, logout, setAuthConfig,
@@ -2632,7 +2675,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     restoreDismissedTips,
     payday, setPayday,
     formatCurrency, formatCurrencyShort, restoreGrowthRateDefaults, restoreCustomTaxRateDefault,
-    demoMode, toggleDemoMode,
+    demoMode, toggleDemoMode, demoLocked, resetDemo,
     onboardingCompleted, onboardingActive, onboardingEntry, onboardingNonce,
     startOnboarding, resetGuide, completeOnboarding,
     dataLoadFailed, authRequired, authEnabled, authSource, login, logout, setAuthConfig,

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -939,6 +939,11 @@ export const translations = {
       demoActive: 'Demomodus er på',
       demoBanner: 'Demomodus — viser eksempeldata, ikke din egen økonomi.',
       demoExit: 'Avslutt',
+      // Public demo instance (server DEMO_MODE): permanent demo, nothing is saved.
+      demoPublicTitle: 'Eksempeldata',
+      demoPublicDesc: 'Dette er en offentlig demo av Headroom, fylt med oppdiktede tall. Prøv gjerne alt — endringene dine blir liggende i denne nettleseren og forsvinner når du laster siden på nytt. Ingenting lagres på serveren, og du kan ikke påvirke det andre ser.',
+      demoPublicBanner: 'Offentlig demo — oppdiktede tall. Endringer blir kun liggende i nettleseren din og lagres aldri.',
+      demoResetData: 'Tilbakestill eksempeldata',
       dataManagement: 'Datahåndtering',
       dataDesc: 'Eksporter eller importer alle dataene dine som JSON.',
       about: 'Om Headroom',
@@ -2735,6 +2740,11 @@ export const translations = {
       demoActive: 'Demo mode is on',
       demoBanner: 'Demo mode — showing sample data, not your real finances.',
       demoExit: 'Exit',
+      // Public demo instance (server DEMO_MODE): permanent demo, nothing is saved.
+      demoPublicTitle: 'Sample data',
+      demoPublicDesc: 'This is a public demo of Headroom, filled with fictional numbers. Try anything you like — your changes stay in this browser and disappear when you reload. Nothing is written to the server, and you cannot affect what anyone else sees.',
+      demoPublicBanner: 'Public demo — fictional numbers. Your changes stay in this browser and are never saved.',
+      demoResetData: 'Reset sample data',
       dataManagement: 'Data management',
       dataDesc: 'Export or import all your data as JSON.',
       about: 'About Headroom',

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -105,6 +105,8 @@ export default function SettingsPage() {
     restoreCustomTaxRateDefault,
     demoMode,
     toggleDemoMode,
+    demoLocked,
+    resetDemo,
     startOnboarding,
     resetGuide,
     restoreDismissedTips,
@@ -875,7 +877,11 @@ export default function SettingsPage() {
                     </div>
                   </label>
 
-                  {/* Restore from a raw SQLite backup (make backup) without a terminal. */}
+                  {/* Restore from a raw SQLite backup (make backup) without a terminal.
+                      Hidden on a public demo: it posts to /api/restore, which a demo
+                      instance refuses, and it's about the owner's deployment anyway.
+                      Export and JSON import above stay — both are client-side. */}
+                  {!demoLocked && (
                   <div className="mt-3 flex items-center gap-2 text-[12px]" style={{ color: 'var(--text-3)' }}>
                     <span>{t.settings.restoreOr}</span>
                     <input
@@ -897,6 +903,7 @@ export default function SettingsPage() {
                       {t.settings.restoreFromBackup}
                     </button>
                   </div>
+                  )}
 
                   {importState === 'error' && (
                     <div
@@ -994,15 +1001,22 @@ export default function SettingsPage() {
         </Card>
 
         {/* ──── Restore points — per-write revision history (span 12) ──── */}
-        <RestorePointsCard />
+        {/* Hidden on a public demo: the demo's volume is ephemeral and holds no
+            revisions, and rolling back posts to an API that refuses writes. */}
+        {!demoLocked && <RestorePointsCard />}
 
         {/* ──── Connect an AI assistant (MCP) — how-to (span 12) ──── */}
         <AiAccessCard />
 
         {/* ═══════ Security ═══════ */}
-        <GroupHeading>{t.settings.groups.security}</GroupHeading>
-
-        <AuthSettings />
+        {/* Setting a password on a public demo would either lock every other
+            visitor out or silently fail against the read-only API. */}
+        {!demoLocked && (
+          <>
+            <GroupHeading>{t.settings.groups.security}</GroupHeading>
+            <AuthSettings />
+          </>
+        )}
 
         {/* ═══════ Advanced ═══════ */}
         <GroupHeading>{t.settings.groups.advanced}</GroupHeading>
@@ -1011,9 +1025,11 @@ export default function SettingsPage() {
         <Card padding="lg" className="md:col-span-12">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
-              <SectionLabel icon={<MonitorPlay />}>{t.settings.demoTitle}</SectionLabel>
+              <SectionLabel icon={<MonitorPlay />}>
+                {demoLocked ? t.settings.demoPublicTitle : t.settings.demoTitle}
+              </SectionLabel>
               <p className="mt-2 text-[13px] max-w-2xl" style={{ color: 'var(--text-2)' }}>
-                {t.settings.demoDesc}
+                {demoLocked ? t.settings.demoPublicDesc : t.settings.demoDesc}
               </p>
             </div>
             {demoMode && (
@@ -1026,13 +1042,17 @@ export default function SettingsPage() {
             )}
           </div>
           <div className="mt-5 flex flex-wrap gap-3">
+            {/* A public demo can't be exited — there's no real data behind it.
+                The equivalent action is putting the sample data back. */}
             <Button
-              variant={demoMode ? 'secondary' : 'primary'}
+              variant={demoMode && !demoLocked ? 'secondary' : 'primary'}
               size="md"
-              leadingIcon={<MonitorPlay />}
-              onClick={toggleDemoMode}
+              leadingIcon={demoLocked ? <RotateCcw /> : <MonitorPlay />}
+              onClick={demoLocked ? resetDemo : toggleDemoMode}
             >
-              {demoMode ? t.settings.demoDeactivate : t.settings.demoActivate}
+              {demoLocked
+                ? t.settings.demoResetData
+                : demoMode ? t.settings.demoDeactivate : t.settings.demoActivate}
             </Button>
             <Button
               variant="secondary"
@@ -1062,6 +1082,10 @@ export default function SettingsPage() {
         </Card>
 
         {/* ──── Danger zone (span 12) ──── */}
+        {/* Hidden on a public demo: wiping the sample data leaves the next
+            visitor an empty app, and "Reset sample data" above is the reset a
+            demo visitor actually wants. */}
+        {!demoLocked && (
         <Card padding="lg" className="md:col-span-12">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div>
@@ -1120,6 +1144,7 @@ export default function SettingsPage() {
             </div>
           )}
         </Card>
+        )}
 
         {/* ──── About (span 12) ──── */}
         <Card padding="lg" className="md:col-span-12">


### PR DESCRIPTION
## Why

I want to show the app off publicly (blog, LinkedIn) — let people click
through a populated Headroom without reaching real data or being able to
change anything for the next visitor.

## What

**Server — `server/demo.js`, the actual boundary.** With `DEMO_MODE=1`:

- every non-GET under `/api/` is refused with `403`
- the whole `/api/bank/*` namespace is refused regardless of method. Its GETs
  are not safe reads: `/api/bank/aspsps` proxies to Enable Banking on the
  instance's own credentials, and `/api/bank/callback` completes a bank link
  as a side effect
- the path is lowercased before matching, so `/API/DATA` cannot slip past and
  still reach the `/api/data` handler (same reasoning as the auth gate)
- rotating backups and scheduled bank sync are skipped

Mounted before the auth gate, so the instance is read-only whether or not auth
is configured. Off unless `DEMO_MODE` is set — a normal deployment is untouched.

**Client.** `GET /api/config` is read before anything else, so a demo instance
boots straight into a locked demo mode filled from the existing
`src/lib/demoData.ts` generator. It never fetches or posts `/api/data`: each
visitor edits a private in-browser sandbox that resets on reload, and no
visitor can affect what another sees. The UI drops what cannot work there —
exit-demo, password settings, restore points, SQLite-backup restore,
delete-all-data — and offers "Reset sample data" instead. Export and JSON
import stay, both being client-side.

Strings added in nb and en; no `lang` branching in JSX.

## Verification

`npx tsc -b && npm run lint && npm test` — 937 passing, 7 new for the gate.

Against a throwaway `DATA_DIR` (never the live volume), all route classes probed:

| | |
|---|---|
| `POST /api/data`, `/api/restore`, `/api/auth/config`, `/api/history/1/restore` | `403` |
| `GET`/`POST` `/api/bank/*` | `403` |
| `POST /API/DATA` | `403` |
| `GET /api/config`, `/api/data`, `/api/version`, `/healthz` | `200` |

A normal instance still reports `{"demoMode":false}` and saves (`POST /api/data → 200`).

In a real browser against the built app in demo mode: dashboard renders
populated with the demo banner, **zero console errors, zero writes,
`/api/data` never requested**. Changing a persisted field (language) applied
locally and issued no network write.

## Notes

Run a demo as a **separate instance**. `DEMO_MODE` protects the API, but
pointing it at your own data volume would still serve that data on
`GET /api/data`. Documented under README "Public demo mode".

Two knowingly-deferred gaps are recorded in `BACKLOG.md`: the rate limiter is
one global bucket that all demo visitors share (availability only), and the
stale-service-worker case, which cannot occur on a fresh deployment.