### PR TITLE
fix: stop treating SSB's publication lag as missing inflation data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY server/index.js ./
 COPY server/auth.js ./
 COPY server/demo.js ./
+COPY server/cpiWindow.js ./
 COPY server/seed.js ./
 COPY server/ssb.js ./
 COPY server/boligPrices.js ./

--- a/server/cpiWindow.js
+++ b/server/cpiWindow.js
@@ -1,0 +1,67 @@
+// How much of a requested CPI window SSB can actually be expected to have.
+//
+// SSB publishes a month's consumer price index roughly ten days after that
+// month ends. A window that runs to "this month" therefore always has one or
+// two trailing months that do not exist upstream yet.
+//
+// /api/inflation used to measure cache completeness against the requested `to`
+// month, which those unpublished months made permanently unreachable: the cache
+// counted as incomplete forever, so a refresh was always "due", and every
+// request landing inside the hourly upstream cooldown reported the data stale.
+// The client renders that as "could not reach SSB" — shown constantly, and
+// wrong, since the fetch had in fact succeeded and returned everything SSB had.
+//
+// Measuring against the publication horizon instead makes "stale" mean what the
+// client says it means: what we are serving is genuinely deficient.
+//
+// Pure and dependency-free (no Express, no SQLite) so it is unit-testable
+// without booting the app — same split as auth.js and demo.js.
+
+/** How far behind the current month SSB's newest published CPI month sits. */
+const SSB_PUBLICATION_LAG_MONTHS = 2;
+
+/** `n` months before a 'YYYY-MM' key (n may be negative to move forward). */
+function shiftMonth(month, n) {
+  const [y, m] = String(month).split('-').map(Number);
+  const d = new Date(Date.UTC(y, m - 1 - n, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Months in an inclusive 'YYYY-MM' range; 0 when `to` precedes `from`. */
+function monthCount(fromMonth, toMonth) {
+  const [fy, fm] = String(fromMonth).split('-').map(Number);
+  const [ty, tm] = String(toMonth).split('-').map(Number);
+  return Math.max(0, (ty - fy) * 12 + (tm - fm) + 1);
+}
+
+/**
+ * The newest month SSB could plausibly have published, as of `nowMonth`.
+ * Zero-padded 'YYYY-MM' keys compare correctly as strings, so callers can use
+ * `<`/`>` on the result directly.
+ */
+function publishedThrough(nowMonth, lagMonths = SSB_PUBLICATION_LAG_MONTHS) {
+  return shiftMonth(nowMonth, lagMonths);
+}
+
+/**
+ * Whether `months` (the CPI months already cached) covers everything the
+ * request needs: every month from `from` through the earlier of `to` and the
+ * publication horizon. Months past that horizon are not required — nobody has
+ * them. A window lying entirely in the unpublished tail is vacuously complete;
+ * there is nothing to fetch and nothing to warn about.
+ */
+function isWindowComplete(months, from, to, nowMonth, lagMonths = SSB_PUBLICATION_LAG_MONTHS) {
+  const horizon = to < publishedThrough(nowMonth, lagMonths) ? to : publishedThrough(nowMonth, lagMonths);
+  if (horizon < from) return true;
+  const have = new Set();
+  for (const m of months) if (m >= from && m <= horizon) have.add(m);
+  return have.size >= monthCount(from, horizon);
+}
+
+module.exports = {
+  SSB_PUBLICATION_LAG_MONTHS,
+  shiftMonth,
+  monthCount,
+  publishedThrough,
+  isWindowComplete,
+};

--- a/server/cpiWindow.test.js
+++ b/server/cpiWindow.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SSB_PUBLICATION_LAG_MONTHS, shiftMonth, monthCount, publishedThrough, isWindowComplete,
+} from './cpiWindow.js';
+
+/** Every month from `from` to `to` inclusive — a fully populated cache. */
+const range = (from, to) => {
+  const out = [];
+  for (let m = from; m <= to; m = shiftMonth(m, -1)) out.push(m);
+  return out;
+};
+
+describe('shiftMonth', () => {
+  it('moves back across a year boundary', () => {
+    expect(shiftMonth('2026-01', 1)).toBe('2025-12');
+    expect(shiftMonth('2026-02', 14)).toBe('2024-12');
+  });
+  it('moves forward on a negative shift', () => {
+    expect(shiftMonth('2025-12', -1)).toBe('2026-01');
+  });
+  it('zero-pads so keys stay string-comparable', () => {
+    expect(shiftMonth('2026-11', 2)).toBe('2026-09');
+    expect('2026-09' < '2026-11').toBe(true);
+  });
+});
+
+describe('monthCount', () => {
+  it('counts an inclusive range', () => {
+    expect(monthCount('2026-01', '2026-01')).toBe(1);
+    expect(monthCount('2025-12', '2026-02')).toBe(3);
+  });
+  it('is 0 rather than negative for an inverted range', () => {
+    expect(monthCount('2026-05', '2026-01')).toBe(0);
+  });
+});
+
+describe('publishedThrough', () => {
+  it('sits the default lag behind the current month', () => {
+    expect(publishedThrough('2026-08')).toBe(shiftMonth('2026-08', SSB_PUBLICATION_LAG_MONTHS));
+    expect(publishedThrough('2026-08', 2)).toBe('2026-06');
+  });
+});
+
+describe('isWindowComplete', () => {
+  // The regression this exists for: the client asks through the CURRENT month,
+  // but SSB's newest published month is ~2 back. Before the fix this window
+  // could never be complete, so `stale` was pinned on and the UI showed
+  // "could not reach SSB" permanently, even right after a successful fetch.
+  it('is complete when the cache holds everything SSB has published', () => {
+    const cached = range('2013-08', '2026-06'); // SSB has nothing newer
+    expect(isWindowComplete(cached, '2013-08', '2026-08', '2026-08', 2)).toBe(true);
+  });
+
+  it('is incomplete when a month inside the published horizon is missing', () => {
+    const cached = range('2013-08', '2026-06').filter(m => m !== '2020-03');
+    expect(isWindowComplete(cached, '2013-08', '2026-08', '2026-08', 2)).toBe(false);
+  });
+
+  it('is incomplete when the cache stops short of the horizon', () => {
+    const cached = range('2013-08', '2026-04'); // two published months behind
+    expect(isWindowComplete(cached, '2013-08', '2026-08', '2026-08', 2)).toBe(false);
+  });
+
+  it('goes incomplete again once SSB publishes a new month', () => {
+    const cached = range('2013-08', '2026-06');
+    // Same cache, a month later: the horizon advances to 2026-07, which is missing.
+    expect(isWindowComplete(cached, '2013-08', '2026-09', '2026-09', 2)).toBe(false);
+  });
+
+  it('does not require months past the horizon even when the cache has them', () => {
+    const cached = range('2013-08', '2026-06');
+    expect(isWindowComplete(cached, '2013-08', '2026-06', '2026-08', 2)).toBe(true);
+  });
+
+  it('treats a window entirely in the unpublished tail as complete', () => {
+    // Nothing to fetch and nothing to warn about — nobody has these months.
+    expect(isWindowComplete([], '2026-07', '2026-08', '2026-08', 2)).toBe(true);
+  });
+
+  it('ignores cached months outside the requested window', () => {
+    const cached = [...range('2010-01', '2012-12'), ...range('2025-01', '2026-06')];
+    expect(isWindowComplete(cached, '2025-01', '2026-08', '2026-08', 2)).toBe(true);
+  });
+
+  it('is not fooled by duplicate rows', () => {
+    const cached = [...range('2025-01', '2026-05'), ...range('2025-01', '2026-05')];
+    // 2026-06 is still genuinely missing; duplicates must not pad the count.
+    expect(isWindowComplete(cached, '2025-01', '2026-08', '2026-08', 2)).toBe(false);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ const { startBackupSchedule, parseCount } = require('./backup');
 const { startBankSyncSchedule } = require('./bankSync');
 const { resolveAuth, hashPassword, createSessionStore, parseCookies, serializeCookie, makeAuthGate } = require('./auth');
 const { isDemoMode, makeDemoGate } = require('./demo');
+const { isWindowComplete } = require('./cpiWindow');
 const pkg = require('./package.json');
 
 // Public read-only demo instance (see server/demo.js). Off unless DEMO_MODE is
@@ -404,12 +405,6 @@ let lastPolicyRateAttemptAt = 0;
 // series, so one shared attempt timer is correct — like policy-rate).
 let lastWageStatsAttemptAt = 0;
 
-function monthCount(fromMonth, toMonth) {
-  const [fy, fm] = fromMonth.split('-').map(Number);
-  const [ty, tm] = toMonth.split('-').map(Number);
-  return (ty - fy) * 12 + (tm - fm) + 1;
-}
-
 // Cheap liveness probe: exercises the DB so a hung event loop / broken SQLite
 // handle fails the healthcheck instead of staying "Up" forever.
 const healthStmt = db.prepare('SELECT 1 AS ok');
@@ -669,11 +664,20 @@ app.get('/api/inflation', async (req, res) => {
   const paddedFrom = `${fy - 1}-${String(fm).padStart(2, '0')}`;
 
   const cached = inflationGetRange.all(paddedFrom, to);
-  const expectedCount = monthCount(paddedFrom, to);
   const latestRow = inflationLatest.get();
   const latestAt = latestRow?.latest ? Date.parse(latestRow.latest) : 0;
   const ageMs = Date.now() - latestAt;
-  const needsRefresh = cached.length < expectedCount || ageMs > CACHE_TTL_MS;
+  // Completeness is measured against what SSB could actually have published,
+  // not against `to`. The client asks through the current month, but CPI lands
+  // ~10 days after a month ends, so the newest month or two of the window never
+  // exists upstream. Counting those as missing made the cache permanently
+  // incomplete: a refresh was always due, so every request inside the hourly
+  // cooldown fell through to the `else if` below and flagged the data stale —
+  // which the client renders as "could not reach SSB", constantly and wrongly.
+  // See server/cpiWindow.js.
+  const nowMonth = new Date().toISOString().slice(0, 7);
+  const haveComplete = isWindowComplete(cached.map(r => r.month), paddedFrom, to, nowMonth);
+  const needsRefresh = !haveComplete || ageMs > CACHE_TTL_MS;
   // A user-initiated refresh bypasses the per-hour attempt cooldown (but not the
   // needsRefresh check — nothing to fetch when the cache is already current).
   const force = req.query.force === '1';
@@ -690,12 +694,15 @@ app.get('/api/inflation', async (req, res) => {
       tx(points);
     } catch (err) {
       console.warn(`[inflation] SSB fetch failed, serving cache (next attempt in ${Math.round(SSB_ATTEMPT_COOLDOWN_MS / 60000)} min):`, err.message);
-      stale = true;
+      // Only a warning if what we're left serving is actually deficient. A
+      // failed fetch while the cache already holds every published month costs
+      // the user nothing, so don't tell them the data is unavailable.
+      stale = !haveComplete;
     }
   } else if (needsRefresh) {
     // Refresh is due but we attempted recently — serve what we have without
-    // touching SSB, flagged stale so the client can show its indicator.
-    stale = true;
+    // touching SSB, flagged stale only if it's genuinely missing months.
+    stale = !haveComplete;
   }
 
   const finalRows = inflationGetRange.all(paddedFrom, to);

--- a/src/lib/salary.test.ts
+++ b/src/lib/salary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH, computeNewGross, priorSalaryForJob, activeJobBreakdown } from './salary';
+import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH, computeNewGross, priorSalaryForJob, activeJobBreakdown, salaryVsCpiYoy } from './salary';
 import type { SalaryEntry, JobEntry, HoursSnapshot } from '../context/FinanceContext';
 
 const sal = (id: string, effectiveDate: string, grossAnnual: number, jobId = 'j1'): SalaryEntry => ({
@@ -185,3 +185,56 @@ describe('activeJobBreakdown', () => {
   });
 });
 
+
+describe('salaryVsCpiYoy', () => {
+  /** 13+ months where every point carries a CPI index. */
+  const withCpi = (n: number, cpiAt: (i: number) => number | undefined) =>
+    Array.from({ length: n }, (_, i) => ({ totalAnnual: 600000, cpiIndex: cpiAt(i) }));
+
+  it('is null when the series cannot span a year', () => {
+    expect(salaryVsCpiYoy(withCpi(12, () => 100))).toBeNull();
+  });
+
+  it('computes salary growth over the trailing 12 months', () => {
+    const s = withCpi(13, () => 100);
+    s[0].totalAnnual = 600000;
+    s[12].totalAnnual = 660000;
+    expect(salaryVsCpiYoy(s)!.salary).toBeCloseTo(10, 6);
+  });
+
+  it('anchors CPI on the newest month that has an index', () => {
+    // The regression: SSB publishes ~2 months late, so the final points have no
+    // cpiIndex. Reading the last point gave undefined, which was treated as 0 —
+    // reporting "CPI +0.0%" and overstating the beats-CPI gap.
+    const s = withCpi(15, i => (i >= 13 ? undefined : 100 + i));
+    // Newest indexed point is i=12 (112); its 12-months-prior is i=0 (100).
+    expect(salaryVsCpiYoy(s)!.cpi).toBeCloseTo(12, 6);
+  });
+
+  it('reports real inflation rather than 0 when the tail is unpublished', () => {
+    // Two unpublished trailing months over a series where CPI rose 3%. The old
+    // code read the final (indexless) point and reported +0.0%.
+    const s = withCpi(15, i => (i >= 13 ? undefined : (i === 12 ? 103 : 100)));
+    expect(salaryVsCpiYoy(s)!.cpi).toBeCloseTo(3, 6);
+  });
+
+  it('is null for cpi when no pair 12 months apart has both indices', () => {
+    const s = withCpi(13, i => (i === 12 ? 110 : undefined));
+    expect(salaryVsCpiYoy(s)!.cpi).toBeNull();
+  });
+
+  it('still reports salary growth when CPI is unavailable', () => {
+    const s = withCpi(13, () => undefined);
+    s[0].totalAnnual = 500000;
+    s[12].totalAnnual = 550000;
+    const r = salaryVsCpiYoy(s)!;
+    expect(r.cpi).toBeNull();
+    expect(r.salary).toBeCloseTo(10, 6);
+  });
+
+  it('guards against a zero prior salary instead of dividing by it', () => {
+    const s = withCpi(13, () => 100);
+    s[0].totalAnnual = 0;
+    expect(salaryVsCpiYoy(s)!.salary).toBe(0);
+  });
+});

--- a/src/lib/salary.ts
+++ b/src/lib/salary.ts
@@ -121,3 +121,43 @@ export function hoursAt(
   }
   return 37.5;
 }
+
+/** One month of the salary series, as far as the CPI comparison is concerned. */
+export interface SalaryCpiPoint {
+  totalAnnual: number;
+  /**
+   * SSB's CPI index for the month. Null/absent for months SSB hasn't published
+   * yet — both spellings occur across the callers, and both are falsy, which is
+   * exactly what the pairing check below tests for.
+   */
+  cpiIndex?: number | null;
+}
+
+/**
+ * Year-over-year salary growth, and the CPI growth to compare it against.
+ *
+ * The CPI side is anchored on the newest month that actually HAS an index,
+ * not on the newest month of the series. SSB publishes a month's CPI about ten
+ * days after that month ends, so the last month or two of the series never has
+ * one. Reading `cpiIndex` straight off the final point yields undefined, and
+ * treating that as 0 asserts that inflation was flat — which silently inflates
+ * the "beats CPI" gap and states something false about the user's money.
+ *
+ * `cpi` is null when no comparable pair exists, so callers can omit the
+ * comparison rather than present a wrong one. Returns null when the series is
+ * too short to span a year.
+ */
+export function salaryVsCpiYoy(series: SalaryCpiPoint[]): { salary: number; cpi: number | null } | null {
+  if (series.length < 13) return null;
+  const last = series[series.length - 1];
+  const prior = series[series.length - 13];
+  const salary = prior.totalAnnual > 0 ? ((last.totalAnnual / prior.totalAnnual) - 1) * 100 : 0;
+
+  let cpi: number | null = null;
+  for (let i = series.length - 1; i >= 12; i--) {
+    const now = series[i].cpiIndex;
+    const then = series[i - 12].cpiIndex;
+    if (now && then) { cpi = ((now / then) - 1) * 100; break; }
+  }
+  return { salary, cpi };
+}

--- a/src/pages/SalaryPage.tsx
+++ b/src/pages/SalaryPage.tsx
@@ -47,7 +47,7 @@ import { CHART, AXIS_PROPS, AXIS_PROPS_Y, GRID_PROPS } from '../lib/chartColors'
 import { calcTaxByRegion, calcMarginalTaxRate } from '../lib/norwegianTax';
 import { restskattEstimate } from '../lib/restskatt';
 import { monthKeyFromDate, addMonthsKey, monthsBetween, yearOf } from '../lib/date';
-import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH, activeJobBreakdown } from '../lib/salary';
+import { salaryAt, hoursAt, nominalHourlyRate, WEEKS_PER_MONTH, activeJobBreakdown, salaryVsCpiYoy } from '../lib/salary';
 import { formatSignedPct, formatAxisInt } from '../lib/format';
 import { isValidYearMonth, isOptionalYearMonth, isNonNegativeNumber, isNonEmpty, parseLocaleNumber } from '../lib/validators';
 import { ChartSkeleton } from '../components/ui/Skeleton';
@@ -189,18 +189,7 @@ const SalaryPage: React.FC = () => {
   // YoY: compare current month to 12 months ago (total comp including on-call).
   // Null with under 13 months of history — a fabricated +0.0% would read as a
   // confident "flat vs inflation" to a new user.
-  const yoy = useMemo(() => {
-    if (series.length < 13) return null;
-    const last = series[series.length - 1];
-    const prior = series[series.length - 13];
-    const salaryPct = prior.totalAnnual > 0
-      ? ((last.totalAnnual / prior.totalAnnual) - 1) * 100
-      : 0;
-    const cpiPct = prior.cpiIndex && last.cpiIndex
-      ? ((last.cpiIndex / prior.cpiIndex) - 1) * 100
-      : 0;
-    return { salary: salaryPct, cpi: cpiPct };
-  }, [series]);
+  const yoy = useMemo(() => salaryVsCpiYoy(series), [series]);
 
   // Effective hourly including bonus + overtime + on-call over trailing 12 months
   const trailingHourly = useMemo(() => {
@@ -553,7 +542,9 @@ const SalaryPage: React.FC = () => {
     );
   }, [isGeneric, payslips, currentMonthKey, region, customTaxRatePct, pension.ipsAnnualContribution, annualMortgageInterest]);
 
-  const yoyChip = yoy ? yoy.salary - yoy.cpi : null;
+  // No chip when CPI is unknown (SSB hasn't published the recent months): a
+  // beats/loses-CPI claim needs a real CPI to compare against.
+  const yoyChip = yoy && yoy.cpi != null ? yoy.salary - yoy.cpi : null;
   const chipColor = yoyChip != null && yoyChip >= 0 ? 'var(--positive)' : 'var(--negative)';
   const chipBg = yoyChip != null && yoyChip >= 0 ? 'var(--positive-bg)' : 'var(--negative-bg)';
 
@@ -687,7 +678,7 @@ const SalaryPage: React.FC = () => {
           <SummaryTile
             label={t.salary.yoyVsInflation}
             value={formatSignedPct(yoy?.salary)}
-            sub={yoy ? `${t.salaryPage.cpi} ${formatSignedPct(yoy.cpi)}` : ''}
+            sub={yoy && yoy.cpi != null ? `${t.salaryPage.cpi} ${formatSignedPct(yoy.cpi)}` : ''}
             chip={yoyChip != null ? (
               <span
                 className="inline-flex items-center px-1.5 py-0.5 rounded-md text-[10px] font-semibold"


### PR DESCRIPTION
## Why

Two bugs, one root cause: SSB publishes a month's CPI about ten days after that
month ends, so the newest month or two of any window running to "today" does not
exist upstream. Both sites treated that absence as a fault rather than as normal.

Found while checking the public demo, but it affects the private instance too.

### 1. A permanent, false "could not reach SSB"

`/api/inflation` measured cache completeness against the requested `to` month:

```js
const expectedCount = monthCount(paddedFrom, to);          // to = current month
const needsRefresh = cached.length < expectedCount || ...  // never satisfiable
```

The unpublished trailing months made that unreachable, so the cache counted as
incomplete forever, a refresh was permanently due, and every request inside the
hourly upstream cooldown fell through to the `else if` that sets `stale = true`.
The client renders that as **"Inflasjonsdata utilgjengelig — kunne ikke nå SSB"**
— shown on every load, and wrong: the fetch had succeeded and returned
everything SSB had.

Completeness is now measured against the publication horizon
(`server/cpiWindow.js`), so `stale` means what the client says it means: what
we're serving is genuinely deficient. The refresh cadence is unchanged — once SSB
publishes a new month the window goes incomplete and refetches promptly.

### 2. A wrong claim about money

The Salary page's year-over-year tile read `cpiIndex` off the final series point,
which for the same reason is null, and fell back to `0`:

```js
const cpiPct = prior.cpiIndex && last.cpiIndex ? ... : 0;
```

That asserts inflation was flat. It displayed **"KPI +0.0%"** and claimed the
salary **beat CPI by 3.9pp** when the real gap was **1.2pp**. This is the
undefined-into-arithmetic class the repo guidelines call out — a confident, wrong
statement about the user's money.

The comparison now anchors on the newest month that actually has an index, and
shows no beats/loses-CPI chip at all when no comparable pair exists rather than
inventing one.

## Verification

`npx tsc -b && npm run lint && npm test` — 976 passing, 21 new.

Against **live SSB** with a throwaway `DATA_DIR`:

| request | before | after |
|---|---|---|
| 1st (cold cache, fetches) | `stale: false` | `stale: false` |
| 2nd (inside hourly cooldown) | `stale: true` | `stale: false` |
| 3rd | `stale: true` | `stale: false` |

143 points through `2026-06` — everything SSB has published.

In the browser: the banner is gone, and the tile reads **KPI +2.7% / +1.2pp**,
matching the `2.697%` year-over-year in the API response.

New tests cover the horizon logic directly — cache complete through the published
horizon, incomplete when a month inside it is missing, incomplete again once SSB
publishes a new month, windows lying entirely in the unpublished tail, and
duplicate rows not padding the count — plus the CPI anchoring and the null case.