### PR TITLE
fix: pair the server and desktop dependency updates in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,32 +36,24 @@ updates:
         applies-to: security-updates
         patterns: ["*"]
 
-  # The desktop app pins its own copy of the server's runtime deps (it runs them
-  # under Electron's Node), so it needs its own update stream.
+  # server/ and desktop/ declare the same runtime dependencies: the desktop app
+  # runs the server under Electron's Node, so it needs its own ABI-matched copy,
+  # and desktop/deps.test.js fails the build if the two drift. Updating them in
+  # separate PRs therefore produces two PRs that each fail on their own. One
+  # entry across both directories, with a single catch-all group so major bumps
+  # are covered too, keeps a shared bump in one mergeable PR.
   - package-ecosystem: "npm"
-    directory: "/desktop"
+    directories:
+      - "/server"
+      - "/desktop"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
     open-pull-requests-limit: 5
     groups:
-      npm-minor-patch:
-        update-types: ["minor", "patch"]
-      npm-security:
-        applies-to: security-updates
+      server-and-desktop:
         patterns: ["*"]
-
-  - package-ecosystem: "npm"
-    directory: "/server"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    open-pull-requests-limit: 5
-    groups:
-      npm-minor-patch:
-        update-types: ["minor", "patch"]
       npm-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ headroom
 | [**Dependency Review**](.github/workflows/dependency-review.yml) | PRs | Blocks PRs that introduce known-vulnerable dependencies |
 | [**Scorecard**](.github/workflows/scorecard.yml) | Push to `main`, weekly | OpenSSF supply-chain score published to the Security tab |
 | [**Container Scan**](.github/workflows/container-scan.yml) | Push to `main`, weekly | Trivy scan of the image; findings to the Security tab |
-| [**Dependabot**](.github/dependabot.yml) | Weekly | Grouped dependency-update PRs (npm root + `server/` + `desktop/`, GitHub Actions) |
+| [**Dependabot**](.github/dependabot.yml) | Weekly | Grouped dependency-update PRs (npm root, `server/`+`desktop/` paired in one PR, Docker, GitHub Actions) |
 
 ---
 


### PR DESCRIPTION
## Why

`server/` and `desktop/` declare the same four runtime dependencies, because the desktop app runs the server under Electron's Node and needs an ABI-matched build of `better-sqlite3`. `desktop/deps.test.js` fails the build when the two drift.

With a separate Dependabot stream per directory, a shared bump arrives as two PRs that each fail CI on their own. #105 (server `express-rate-limit` 7.5.1 to 8.6.2) is red right now for exactly this reason, and #106 is its unmergeable twin.

## What

One multi-directory entry covering `/server` and `/desktop`, so a shared bump lands in a single PR touching both.

The group is a catch-all (`patterns: ["*"]`) rather than the previous minor/patch grouping. That grouping left major bumps ungrouped, and both open pairs are majors: `express-rate-limit` 7 to 8 and `better-sqlite3` 12 to 13.

## Verification

Config parses, no tabs. The behaviour change is visible only when Dependabot next runs.

## Follow-up

The already-open PRs predate this config and are unaffected by it: #95 with #107 (`better-sqlite3`) and #105 with #106 (`express-rate-limit`) each need merging as a pair, or closing so Dependabot reopens them combined.