### PR TITLE
ci: make the desktop build a reportable required check

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -3,14 +3,14 @@ name: Desktop build
 # Builds the Mac and Windows installers. Runs on PRs that touch the code they
 # package (so a break surfaces before release rather than at release), and is
 # called by the release workflow to produce the real artifacts.
+#
+# There is deliberately no `paths:` filter here. A required status check has to
+# report on EVERY pull request — a filtered-out workflow reports nothing at all,
+# and a PR waiting on a check that will never arrive is stuck forever. So the
+# filtering moved into the `changes` job, and the `gate` job at the bottom always
+# reports. `gate` is the one to mark required; the three build jobs are not.
 on:
   pull_request:
-    paths:
-      - 'desktop/**'
-      - 'server/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -32,8 +32,47 @@ defaults:
     shell: bash
 
 jobs:
+  # The path filter that used to live under `on:`. Kept to `contents: read` on
+  # purpose: release.yml calls this workflow with only that permission, and a
+  # reusable workflow cannot request more than its caller was granted.
+  changes:
+    name: Detect packaged changes
+    runs-on: ubuntu-latest
+    outputs:
+      packaged: ${{ steps.filter.outputs.packaged }}
+    steps:
+      # Only a pull_request needs a diff — a release call or a manual run always
+      # builds. On a PR, checkout lands on the merge commit, so HEAD^1 is the base
+      # and `git diff HEAD^1 HEAD` is exactly this PR's changes; depth 2 is enough
+      # to have both, and avoids cloning the full history.
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 2
+
+      - name: Decide whether the installers need building
+        id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT" != 'pull_request' ]]; then
+            echo 'packaged=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only HEAD^1 HEAD)
+          echo "Changed files:"; echo "$changed"
+          # Keep this list in step with what the installers actually package.
+          if grep -qE '^(desktop/|server/|package\.json$|package-lock\.json$|\.github/workflows/desktop-build\.yml$)' <<< "$changed"; then
+            echo 'packaged=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'packaged=false' >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: ${{ matrix.label }}
+    needs: changes
+    if: needs.changes.outputs.packaged == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -108,3 +147,30 @@ jobs:
             desktop/release/*.exe
           if-no-files-found: error
           retention-days: 7
+
+  # The single check to mark required. It reports on every PR: green when the
+  # installers built, green when nothing they package changed, red otherwise.
+  # `always()` is what makes it report even when `build` was skipped — without it
+  # a skipped dependency skips this too, which is the whole failure mode.
+  gate:
+    name: Desktop installers
+    runs-on: ubuntu-latest
+    needs: [changes, build]
+    if: always()
+    steps:
+      - name: Report
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          BUILD: ${{ needs.build.result }}
+        run: |
+          # A broken detector must not pass as "nothing to build" — that would
+          # wave through exactly the breakage this check exists to catch.
+          if [[ "$CHANGES" != 'success' ]]; then
+            echo "::error::Change detection $CHANGES — cannot tell whether the installers needed building."
+            exit 1
+          fi
+          case "$BUILD" in
+            success) echo 'Installers built.' ;;
+            skipped) echo 'Nothing the installers package changed; not built.' ;;
+            *)       echo "::error::Desktop build $BUILD."; exit 1 ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ headroom
 |----------|---------|---------|
 | [**CI**](.github/workflows/build.yml) | Push to `main`, PRs, manual | Typecheck, lint, test, then build and push the Docker image to GHCR |
 | [**Release**](.github/workflows/release.yml) | Push to `main` | release-please keeps a release PR open; merging it cuts the release and attaches the desktop installers |
-| [**Desktop build**](.github/workflows/desktop-build.yml) | PRs touching `desktop/`/`server/`, manual | Builds the Mac and Windows installers so a break surfaces before release |
+| [**Desktop build**](.github/workflows/desktop-build.yml) | All PRs, manual | Builds the Mac and Windows installers so a break surfaces before release. Installers build only when a PR touches what they package; the `Desktop installers` check reports either way, so it can be a required check |
 | [**Dependency Review**](.github/workflows/dependency-review.yml) | PRs | Blocks PRs that introduce known-vulnerable dependencies |
 | [**Scorecard**](.github/workflows/scorecard.yml) | Push to `main`, weekly | OpenSSF supply-chain score published to the Security tab |
 | [**Container Scan**](.github/workflows/container-scan.yml) | Push to `main`, weekly | Trivy scan of the image; findings to the Security tab |


### PR DESCRIPTION
## Why

Closes the gap flagged during the dependency audit (#116).

The three desktop build jobs could not be made required status checks. `desktop-build.yml` was filtered to PRs touching `desktop/`, `server/`, `package.json` or `package-lock.json`, and **a filtered-out workflow reports nothing at all** — so requiring it would leave every unrelated PR blocked forever on a check that never arrives.

That matters now that Dependabot auto-merges security updates at any size, majors included. The four required checks (`Typecheck, lint & test`, `dependency-review`, both container arches) don't cover Electron packaging, so a bump that breaks the installers can merge on green.

## What

The filter moves out of `on:` and into the jobs.

- **`changes`** diffs the PR to decide whether anything the installers package was touched. On a `pull_request` checkout lands on the merge commit, so `git diff HEAD^1 HEAD` is exactly this PR's changes and `fetch-depth: 2` is enough — no full clone. Anything that isn't a PR (the release call, a manual run) always builds.
- **`build`** is unchanged apart from gaining `needs: changes` and an `if:`.
- **`gate`**, named `Desktop installers`, runs with `if: always()` and reports on every PR: green when the installers built, green when nothing they package changed, red otherwise. This is the check to mark required — not the three build jobs.

Two things worth pointing at in review:

- `changes` deliberately stays on `contents: read`. `release.yml` calls this workflow with only that permission and a reusable workflow cannot request more than its caller was granted, which rules out reading the PR files API.
- A failed detector fails the gate. Treating it as "nothing to build" would wave through exactly the breakage the check exists to catch.

The cost is that the packaged-paths list now lives in a grep rather than the `paths:` key, so it has to be kept in step by hand. It's commented as such.

## Verification

- `actionlint` — clean, no new findings.
- This PR touches `.github/workflows/desktop-build.yml`, which is in the packaged list, so it exercises the **build** path: all three installers should build and `Desktop installers` should report green.
- The **skip** path can only be exercised once this is on `main` (a `pull_request` runs the workflow from the PR head, so a branch cut from today's `main` would still use the filtered version). I'll verify it with a throwaway docs-only PR before the check is marked required.

## Follow-up

Marking `Desktop installers` required in the `protect-default-branch` ruleset is a repo-settings change, done after the skip path is confirmed green.