### PR TITLE
test: verify the desktop gate skip path (do not merge)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,3 +12,5 @@ https://github.com/mortennordbye/headroom/security/advisories/new
 (the "Report a vulnerability" button under this repository's **Security** tab;
 private vulnerability reporting is enabled). You will receive an acknowledgement
 within 48 hours.
+
+<!-- gate skip-path verification, reverted immediately -->


### PR DESCRIPTION
Throwaway PR. Touches only `SECURITY.md`, i.e. nothing the installers package, to confirm `Desktop installers` reports green while the three build jobs skip. Closing as soon as the checks report — this must not merge.