### PR TITLE
feat: project future months on the balance pages

### DIFF
--- a/src/components/HistoryManagerModal.tsx
+++ b/src/components/HistoryManagerModal.tsx
@@ -10,6 +10,7 @@ import {
   nearestSnapshot,
   historyRows,
   buildManualSnapshot,
+  snapshotBalances,
   type SnapshotBalances,
 } from '../lib/snapshots';
 
@@ -43,31 +44,6 @@ function StatePill({ state, hm, liveLabel }: {
       {tone.label}
     </span>
   );
-}
-
-/** The initial balances for the editor: the existing snapshot, else the nearest
- *  recorded month, else the live state. */
-function balancesFrom(base: BalanceSnapshot, live: {
-  savingsTargetPercent: number; growthReturnRate: number; houseGrowthRate: number;
-}): SnapshotBalances {
-  const a = base.assets;
-  return {
-    savingsAccounts: (a.savingsAccounts ?? []).map(s => ({ ...s })),
-    bsu: a.bsu ?? 0,
-    bufferAccount: a.bufferAccount ?? 0,
-    portfolio: a.portfolio ?? 0,
-    crypto: a.crypto ?? 0,
-    houseValue: a.houseValue ?? 0,
-    houseDebt: a.houseDebt ?? 0,
-    debts: (base.debts ?? []).map(d => ({ ...d })),
-    otpBalance: base.pension?.otpBalance ?? 0,
-    ipsBalance: base.pension?.ipsBalance ?? 0,
-    assumptions: base.assumptions ?? {
-      savingsTargetPercent: live.savingsTargetPercent,
-      growthReturnRate: live.growthReturnRate,
-      houseGrowthRate: live.houseGrowthRate,
-    },
-  };
 }
 
 export default function HistoryManagerModal({ onClose, initialMonth }: HistoryManagerModalProps) {
@@ -125,7 +101,7 @@ export default function HistoryManagerModal({ onClose, initialMonth }: HistoryMa
     return (
       <SnapshotEditor
         monthTitle={monthLabel(editing)}
-        initial={balancesFrom(base, { savingsTargetPercent, growthReturnRate, houseGrowthRate })}
+        initial={snapshotBalances(base, { savingsTargetPercent, growthReturnRate, houseGrowthRate })}
         base={base}
         onCancel={done}
         onSave={(balances) => {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import {
 import { format, parse, subMonths, addMonths, startOfMonth, isSameMonth } from 'date-fns';
 import { nb, enUS } from 'date-fns/locale';
 import { useFinanceSettings } from '../context/FinanceContext';
+import { PROJECTION_HORIZON_MONTHS } from '../lib/snapshots';
 import { useBalanceHistory } from '../hooks/useBalanceHistory';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import OnboardingTour from './onboarding/OnboardingTour';
@@ -36,7 +37,7 @@ const BALANCE_SCOPED_ROUTES = ['/assets', '/bolig', '/pension'];
 const HIDE_TIME_MARKER_ROUTES = ['/settings', '/year'];
 
 const Layout: React.FC = () => {
-  const { t, lang, currentMonth, setCurrentMonth, dataLoadFailed, saveFailed, justSaved, retrySave, dataReloaded, dismissDataReloaded, hiddenNavItems, demoMode, toggleDemoMode, demoLocked, startOnboarding } = useFinanceSettings();
+  const { t, lang, currentMonth, setCurrentMonth, projectionIncludeGrowth, setProjectionIncludeGrowth, dataLoadFailed, saveFailed, justSaved, retrySave, dataReloaded, dismissDataReloaded, hiddenNavItems, demoMode, toggleDemoMode, demoLocked, startOnboarding } = useFinanceSettings();
   const hist = useBalanceHistory();
   const dateLocale = lang === 'nb' ? nb : enUS;
   const location = useLocation();
@@ -55,17 +56,27 @@ const Layout: React.FC = () => {
   const isVisible = (path: string) => path === ALWAYS_VISIBLE_NAV || !hiddenNavItems.includes(path);
 
   // One shared month control. Budget & Dashboard are always month-scoped; balance
-  // pages ride the same picker but only once there's recorded history to travel to
-  // (else just the static "today" marker). Settings hides it entirely.
+  // pages ride the same picker in both directions — back through recorded
+  // snapshots, forward into a projection — so it shows regardless of history.
+  // Settings hides it entirely.
   const isMonthScoped = MONTH_SCOPED_ROUTES.includes(location.pathname);
   const isBalanceRoute = BALANCE_SCOPED_ROUTES.includes(location.pathname);
-  const showPicker = isMonthScoped || (isBalanceRoute && hist.hasHistory);
+  const showPicker = isMonthScoped || isBalanceRoute;
   const hideTimeMarker = HIDE_TIME_MARKER_ROUTES.includes(location.pathname);
 
   const today = new Date();
   const isCurrentMonth = isSameMonth(currentMonth, today);
   const isPast = currentMonth < startOfMonth(today);
   const viewKey = format(currentMonth, 'yyyy-MM');
+  // The projection holds income at today's figure, so it stops being meaningful
+  // well before it stops being computable. Cap the forward reach rather than
+  // inventing a fourth "too far ahead" state for every balance page to render.
+  const maxMonth = addMonths(startOfMonth(today), PROJECTION_HORIZON_MONTHS);
+  const canStepForward = currentMonth < maxMonth;
+  const stepMonth = (delta: number) => {
+    const next = addMonths(currentMonth, delta);
+    setCurrentMonth(next > maxMonth ? maxMonth : next);
+  };
 
   // Month ⇄ URL. On first mount, adopt a valid ?m=YYYY-MM so a refresh or shared
   // link lands on that month.
@@ -73,8 +84,11 @@ const Layout: React.FC = () => {
     const m = searchParams.get('m');
     if (m && /^\d{4}-\d{2}$/.test(m)) {
       const parsed = startOfMonth(parse(m, 'yyyy-MM', new Date()));
-      if (!isNaN(parsed.getTime()) && format(parsed, 'yyyy-MM') !== viewKey) {
-        setCurrentMonth(parsed);
+      // Clamp here too: the steppers stop at the horizon, but a shared or stale
+      // link carries a raw month and would otherwise project decades ahead.
+      const clamped = parsed > maxMonth ? maxMonth : parsed;
+      if (!isNaN(parsed.getTime()) && format(clamped, 'yyyy-MM') !== viewKey) {
+        setCurrentMonth(clamped);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -94,7 +108,10 @@ const Layout: React.FC = () => {
   // Balance pages are read-only for any non-current month, and snap the picked
   // month to the nearest recorded snapshot — surface both cues in the chip.
   const balanceReadOnly = isBalanceRoute && !hist.isLive;
-  const snappedToEarlier = balanceReadOnly && hist.activeKey !== viewKey;
+  const snappedToEarlier = balanceReadOnly && !hist.isProjected && hist.activeKey !== viewKey;
+  // A projection is a computed figure, not a record, so it gets its own cue and
+  // its own control: whether assumed growth rides along with the transfers.
+  const showProjectionControls = isBalanceRoute && hist.isProjected;
   const statusColor = isCurrentMonth
     ? 'var(--positive)'
     : isPast
@@ -192,14 +209,15 @@ const Layout: React.FC = () => {
                   // Left/Right step months when focus is anywhere in the picker
                   // (e.g. on a stepper button), so it's operable without the mouse.
                   if (e.key === 'ArrowLeft') { e.preventDefault(); setCurrentMonth(subMonths(currentMonth, 1)); }
-                  else if (e.key === 'ArrowRight') { e.preventDefault(); setCurrentMonth(addMonths(currentMonth, 1)); }
+                  else if (e.key === 'ArrowRight' && canStepForward) { e.preventDefault(); stepMonth(1); }
                 }}
                 className="flex items-center gap-1 rounded-[6px] border p-1 transition-colors"
                 style={{
                   background: statusBg,
                   borderColor: isCurrentMonth ? 'color-mix(in srgb, var(--positive) 35%, transparent)' : 'var(--border)',
                 }}
-                title={balanceReadOnly ? t.timeMachine.readOnly : statusLabel}
+                title={showProjectionControls ? t.timeMachine.projected
+                  : balanceReadOnly ? t.timeMachine.readOnly : statusLabel}
               >
                 <button
                   onClick={() => setCurrentMonth(subMonths(currentMonth, 1))}
@@ -212,7 +230,9 @@ const Layout: React.FC = () => {
                   <ChevronLeft size={15} strokeWidth={2} />
                 </button>
                 <div className="flex items-center gap-1.5 px-2 min-w-[104px] justify-center">
-                  {balanceReadOnly ? (
+                  {showProjectionControls ? (
+                    <TrendingUp size={12} strokeWidth={2} style={{ color: statusColor }} aria-hidden />
+                  ) : balanceReadOnly ? (
                     <Lock size={12} strokeWidth={2} style={{ color: statusColor }} aria-hidden />
                   ) : (
                     <span
@@ -226,11 +246,13 @@ const Layout: React.FC = () => {
                   </span>
                 </div>
                 <button
-                  onClick={() => setCurrentMonth(addMonths(currentMonth, 1))}
+                  onClick={() => stepMonth(1)}
+                  disabled={!canStepForward}
                   aria-label={t.nextMonth}
-                  className="grid place-items-center w-7 h-7 rounded-[4px] transition-colors"
-                  style={{ color: 'var(--text-2)' }}
-                  onMouseEnter={e => (e.currentTarget.style.color = 'var(--text-1)')}
+                  title={canStepForward ? undefined : t.timeMachine.horizonReached}
+                  className="grid place-items-center w-7 h-7 rounded-[4px] transition-colors disabled:cursor-not-allowed"
+                  style={{ color: 'var(--text-2)', opacity: canStepForward ? 1 : 0.35 }}
+                  onMouseEnter={e => { if (canStepForward) e.currentTarget.style.color = 'var(--text-1)'; }}
                   onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-2)')}
                 >
                   <ChevronRight size={15} strokeWidth={2} />
@@ -245,7 +267,28 @@ const Layout: React.FC = () => {
                   {t.timeMachine.asOf} {format(parse(hist.activeKey, 'yyyy-MM', new Date()), 'MMM yyyy', { locale: dateLocale })}
                 </span>
               )}
-              {balanceReadOnly && (
+              {showProjectionControls && (
+                <button
+                  onClick={() => setProjectionIncludeGrowth(!projectionIncludeGrowth)}
+                  aria-pressed={projectionIncludeGrowth}
+                  aria-label={t.timeMachine.growthToggle}
+                  /* Visible at every width, unlike the other header actions: this
+                     is the only control over what a projected figure means, and
+                     the phone is where these pages actually get read. The label
+                     folds away on small screens; the icon and state carry it. */
+                  className="inline-flex items-center gap-1.5 px-2.5 sm:px-3 h-8 rounded-[6px] text-[12px] font-semibold border transition-colors"
+                  style={{
+                    borderColor: projectionIncludeGrowth ? 'var(--violet)' : 'var(--border)',
+                    background: projectionIncludeGrowth ? 'var(--violet-bg)' : 'transparent',
+                    color: projectionIncludeGrowth ? 'var(--violet)' : 'var(--text-2)',
+                  }}
+                  title={projectionIncludeGrowth ? t.timeMachine.growthOnHint : t.timeMachine.growthOffHint}
+                >
+                  <TrendingUp size={12} strokeWidth={2} />
+                  <span className="hidden sm:inline">{t.timeMachine.growthToggle}</span>
+                </button>
+              )}
+              {balanceReadOnly && !hist.isProjected && (
                 <button
                   onClick={() => setEditMonthOpen(true)}
                   className="hidden sm:inline-flex items-center gap-1.5 px-3 h-8 rounded-[6px] text-[12px] font-semibold border transition-colors"

--- a/src/context/FinanceContext.tsx
+++ b/src/context/FinanceContext.tsx
@@ -621,6 +621,12 @@ interface FinanceSettingsContextType {
   setCustomCurrencyRate: (rate: number) => void;
   currentMonth: Date;
   setCurrentMonth: (date: Date) => void;
+  /** On a projected (future) month, whether to compound the assumed growth rates
+   *  on top of the automated transfers. Off by default: a projection made only of
+   *  transfers you configured is reproducible by hand, one built on a slider is
+   *  not. View state like `currentMonth` — deliberately not persisted. */
+  projectionIncludeGrowth: boolean;
+  setProjectionIncludeGrowth: (v: boolean) => void;
   savingsTargetPercent: number;
   setSavingsTargetPercent: (val: number) => void;
   growthReturnRate: number;
@@ -740,6 +746,14 @@ interface FinanceDataContextType {
   removePayslip: (monthKey: string) => void;
   netWorthHistory: Record<string, number>;
   balanceSnapshots: Record<string, BalanceSnapshot>;
+  /** Today's balances in snapshot shape — the record the capture effect stores,
+   *  and the base a projected future month grows forward from. */
+  liveBalanceSnapshot: BalanceSnapshot;
+  /** The automation rule set and the balances it acts on. Exposed so a future
+   *  month can be projected with the same pure runner that posts the real one;
+   *  the runner itself is driven off the real clock and ignores the picked month. */
+  automationRules: AutomationRule[];
+  automationState: AutomationState;
   /** Backfill/edit a manual snapshot for a past month (source forced to 'manual'). */
   setManualSnapshot: (monthKey: string, snapshot: BalanceSnapshot) => void;
   /** Delete a manual snapshot. Auto snapshots are left alone (they re-capture). */
@@ -1101,6 +1115,9 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     const n = new Date();
     return new Date(n.getFullYear(), n.getMonth(), 1);
   });
+  // Same rationale as `currentMonth`: a view control, so it is neither persisted
+  // nor exported. Each session starts on the reproducible, contributions-only view.
+  const [projectionIncludeGrowth, setProjectionIncludeGrowth] = useState(false);
 
   const [income, setIncome] = useState<number>(55000);
   const [monthlyIncomes, setMonthlyIncomes] = useState<Record<string, number>>({});
@@ -2099,6 +2116,20 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [netWorth]);
 
+  // Today's balances in snapshot shape. Two readers: the capture effect below
+  // stores it as this month's record, and a projected future month grows it
+  // forward (see `useBalanceHistory`). One memo so the two can never disagree
+  // about which fields make up "the balance state".
+  const liveBalanceSnapshot = useMemo<BalanceSnapshot>(() => ({
+    assets, loan, pension, homeowner, transition, housingMode, debts,
+    v: 2,
+    fixedExpenses,
+    assumptions: { savingsTargetPercent, growthReturnRate, houseGrowthRate },
+    categoryBudgets,
+    source: 'auto',
+  }), [assets, loan, pension, homeowner, transition, housingMode, debts,
+       fixedExpenses, savingsTargetPercent, growthReturnRate, houseGrowthRate, categoryBudgets]);
+
   // Capture the full balance state for the current calendar month whenever it
   // changes, so the balance pages can be viewed historically later. This state is
   // not month-scoped, so we always target the real current month regardless of the
@@ -2106,14 +2137,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!loaded.current) return;
     const nowKey = format(new Date(), 'yyyy-MM');
-    const snap: BalanceSnapshot = {
-      assets, loan, pension, homeowner, transition, housingMode, debts,
-      v: 2,
-      fixedExpenses,
-      assumptions: { savingsTargetPercent, growthReturnRate, houseGrowthRate },
-      categoryBudgets,
-      source: 'auto',
-    };
+    const snap = liveBalanceSnapshot;
     // Skip the rewrite when the stored snapshot is structurally identical —
     // the slices get fresh identities on every load/adopt, and rewriting the
     // entry anyway would dirty the data on a plain open (3.2).
@@ -2122,8 +2146,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
         ? prev
         : { ...prev, [nowKey]: snap }
     ));
-  }, [assets, loan, pension, homeowner, transition, housingMode, debts,
-      fixedExpenses, savingsTargetPercent, growthReturnRate, houseGrowthRate, categoryBudgets]);
+  }, [liveBalanceSnapshot]);
 
   // The current home's value and mortgage are one real quantity stored in three
   // slices (assets drives net worth; homeowner drives LTV/payment; transition
@@ -2798,6 +2821,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     lang, setLang, t, displayCurrency, setDisplayCurrency, nokToUsd, setNokToUsd,
     customCurrencyCode, setCustomCurrencyCode, customCurrencyRate, setCustomCurrencyRate,
     currentMonth, setCurrentMonth,
+    projectionIncludeGrowth, setProjectionIncludeGrowth,
     savingsTargetPercent, setSavingsTargetPercent,
     growthReturnRate, setGrowthReturnRate, forecastAssumptions, setForecastAssumptions,
     houseGrowthRate, setHouseGrowthRate,
@@ -2825,7 +2849,7 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     saveFailed, justSaved, retrySave, dataReloaded, dismissDataReloaded,
   }), [
     lang, t, displayCurrency, nokToUsd, customCurrencyCode, customCurrencyRate,
-    currentMonth, savingsTargetPercent, growthReturnRate, forecastAssumptions, houseGrowthRate,
+    currentMonth, projectionIncludeGrowth, savingsTargetPercent, growthReturnRate, forecastAssumptions, houseGrowthRate,
     cashGrowthRate, cryptoGrowthRate, region, customTaxRatePct, aiContext, profile, updateProfile,
     capacityOverrides, setCapacityOverride, employerSalaryOverride, setEmployerSalaryOverride,
     dismissedLinkSuggestions, dismissLinkSuggestion, dismissedRecurringSuggestions, dismissRecurringSuggestion,
@@ -2847,7 +2871,8 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
     income, setIncome,
     monthlyIncomes, setMonthlyIncomeForMonth, clearMonthlyIncomeForMonth,
     payslips, setPayslip, removePayslip,
-    netWorthHistory, balanceSnapshots,
+    netWorthHistory, balanceSnapshots, liveBalanceSnapshot,
+    automationRules, automationState,
     setManualSnapshot, deleteManualSnapshot, clearHistory,
     fixedExpenses, setFixedExpenses,
     debts, setDebts,
@@ -2881,7 +2906,8 @@ export function FinanceProvider({ children }: { children: ReactNode }) {
   }), [
     income, monthlyIncomes, setMonthlyIncomeForMonth, clearMonthlyIncomeForMonth,
     payslips, setPayslip, removePayslip, netWorthHistory,
-    balanceSnapshots, setManualSnapshot, deleteManualSnapshot, clearHistory,
+    balanceSnapshots, liveBalanceSnapshot, automationRules, automationState,
+    setManualSnapshot, deleteManualSnapshot, clearHistory,
     fixedExpenses, debts, dailyTransactions,
     setDailyTransactionsTracked, accountLabels, setAccountLabel, applyBankSync,
     categoryRules, addCategoryRule, removeCategoryRule, labelRules, addLabelRule, removeLabelRule,

--- a/src/hooks/useBalanceHistory.ts
+++ b/src/hooks/useBalanceHistory.ts
@@ -1,16 +1,23 @@
 import { useMemo } from 'react';
 import { format } from 'date-fns';
-import { useFinance, type BalanceSnapshot } from '../context/FinanceContext';
-import { snapToRecordedMonth } from '../lib/snapshots';
+import { useFinance, useFinanceSettings, type BalanceSnapshot } from '../context/FinanceContext';
+import {
+  resolveMonthView, buildManualSnapshot, snapshotBalances, type MonthMode,
+} from '../lib/snapshots';
+import { projectSnapshotBalances, type ProjectionRates } from '../lib/projectBalances';
 
 export interface BalanceHistory {
-  /** The recorded snapshot month being shown ('yyyy-MM'). The freely-picked
-   *  header month is snapped to this: the live month when current/future, else
-   *  the latest recorded snapshot at or before it. */
+  /** The month being shown ('yyyy-MM'). For a past month the freely-picked header
+   *  month is snapped to the latest recorded snapshot at or before it; for the
+   *  current or a future month it is the picked month itself. */
   activeKey: string;
-  /** True when viewing the current (or a future) month — the page is editable. */
+  /** How `snapshot` was obtained — recorded fact, live state, or computed. */
+  mode: MonthMode;
+  /** True when viewing the current month — the page is editable. */
   isLive: boolean;
-  /** The snapshot for the active month, or null when live. */
+  /** True when the figures are a forward projection rather than a record. */
+  isProjected: boolean;
+  /** The snapshot for the active month: recorded, projected, or null when live. */
   snapshot: BalanceSnapshot | null;
   /** True when there's at least one recorded snapshot to travel to. */
   hasHistory: boolean;
@@ -18,14 +25,26 @@ export interface BalanceHistory {
 
 /**
  * Balance-page view of the single shared month (`currentMonth`). The whole app
- * now tracks one month; balance pages can't show data for a month that was never
- * recorded, so they *snap* the picked month to the nearest recorded snapshot at
- * or before it (current/future months are "live" and editable). This keeps the
- * "never render an empty month with misleading live data" contract while the one
- * header picker drives every page.
+ * tracks one month; balance pages resolve it three ways — a recorded snapshot for
+ * the past, live state for today, and a computed projection for the future.
+ *
+ * The projection exists because the alternative was worse: a future month used to
+ * resolve to *live* data, so the page showed today's balances under next month's
+ * label and left them editable. Now it shows what the automation will have moved
+ * by then, read-only.
+ *
+ * Nothing here writes. The projected snapshot is assembled per render and never
+ * reaches `balanceSnapshots`; the capture effect, the automation rule set and the
+ * runner all read the real clock, so they cannot see the picked month at all.
  */
 export function useBalanceHistory(): BalanceHistory {
-  const { balanceSnapshots, currentMonth } = useFinance();
+  const {
+    balanceSnapshots, liveBalanceSnapshot, automationRules, automationState,
+  } = useFinance();
+  const {
+    currentMonth, projectionIncludeGrowth,
+    savingsTargetPercent, growthReturnRate, houseGrowthRate, cashGrowthRate, cryptoGrowthRate,
+  } = useFinanceSettings();
   const nowKey = format(new Date(), 'yyyy-MM');
   const viewKey = format(currentMonth, 'yyyy-MM');
 
@@ -34,10 +53,29 @@ export function useBalanceHistory(): BalanceHistory {
     [balanceSnapshots],
   );
 
-  const { activeKey, isLive } = useMemo(
-    () => snapToRecordedMonth(recordedKeys, viewKey, nowKey),
+  const { activeKey, mode } = useMemo(
+    () => resolveMonthView(recordedKeys, viewKey, nowKey),
     [recordedKeys, viewKey, nowKey],
   );
+
+  const rates: ProjectionRates | undefined = useMemo(
+    () => (projectionIncludeGrowth
+      ? { portfolio: growthReturnRate, cash: cashGrowthRate, crypto: cryptoGrowthRate, house: houseGrowthRate }
+      : undefined),
+    [projectionIncludeGrowth, growthReturnRate, cashGrowthRate, cryptoGrowthRate, houseGrowthRate],
+  );
+
+  const projected = useMemo(() => {
+    if (mode !== 'projected') return null;
+    const base = snapshotBalances(liveBalanceSnapshot, {
+      savingsTargetPercent, growthReturnRate, houseGrowthRate,
+    });
+    return buildManualSnapshot(
+      liveBalanceSnapshot,
+      projectSnapshotBalances(base, automationRules, automationState, activeKey, nowKey, rates),
+    );
+  }, [mode, liveBalanceSnapshot, automationRules, automationState, activeKey, nowKey, rates,
+      savingsTargetPercent, growthReturnRate, houseGrowthRate]);
 
   // "Has history" counts recorded months other than the live one — that's what
   // makes the time machine worth showing.
@@ -45,8 +83,10 @@ export function useBalanceHistory(): BalanceHistory {
 
   return {
     activeKey,
-    isLive,
-    snapshot: isLive ? null : balanceSnapshots[activeKey] ?? null,
+    mode,
+    isLive: mode === 'live',
+    isProjected: mode === 'projected',
+    snapshot: mode === 'live' ? null : mode === 'projected' ? projected : balanceSnapshots[activeKey] ?? null,
     hasHistory,
   };
 }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -609,6 +609,11 @@ export const translations = {
       readOnly: 'Skrivebeskyttet historikk – gå til i dag for å redigere',
       asOf: 'per',
       editMonth: 'Rediger måneden',
+      projected: 'Framskrevet – dette er ikke registrerte tall, men det de faste overføringene har flyttet innen da.',
+      horizonReached: 'Lenger fram enn to år framskriver vi ikke – inntekten holdes på dagens nivå.',
+      growthToggle: 'Med avkastning',
+      growthOnHint: 'Antatt avkastning er lagt til overføringene. Tallene følger forutsetningene dine, ikke bare det du har satt opp.',
+      growthOffHint: 'Bare de faste overføringene. Hver krone kan spores til noe du selv har satt opp – slå på for å legge til antatt avkastning.',
     },
     salary: {
       importPayslip: {
@@ -2474,6 +2479,11 @@ export const translations = {
       readOnly: 'Read-only history — go to today to edit',
       asOf: 'as of',
       editMonth: 'Edit month',
+      projected: 'Projected — not recorded figures, but what your standing transfers will have moved by then.',
+      horizonReached: 'We do not project beyond two years — income is held at today\'s level.',
+      growthToggle: 'With growth',
+      growthOnHint: 'Assumed growth is added on top of the transfers. The figures now follow your assumptions, not just what you set up.',
+      growthOffHint: 'The standing transfers only. Every krone traces to something you configured — switch on to add assumed growth.',
     },
     salary: {
       importPayslip: {

--- a/src/lib/projectBalances.test.ts
+++ b/src/lib/projectBalances.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { projectSnapshotBalances, monthsAhead, type ProjectionRates } from './projectBalances';
+import type { AutomationRule, AutomationState } from './automation';
+import type { SnapshotBalances } from './snapshots';
+
+const NOW = '2026-08';
+
+const base = (over: Partial<SnapshotBalances> = {}): SnapshotBalances => ({
+  savingsAccounts: [{ id: 'sav-1', name: 'Ferie', balance: 10_000 } as SnapshotBalances['savingsAccounts'][number]],
+  bsu: 50_000,
+  bufferAccount: 20_000,
+  portfolio: 656_009,
+  crypto: 5_000,
+  houseValue: 4_000_000,
+  houseDebt: 2_000_000,
+  debts: [{ id: 'd-1', name: 'Studielån', balance: 200_000, rate: 5 } as SnapshotBalances['debts'][number]],
+  otpBalance: 300_000,
+  ipsBalance: 100_000,
+  ...over,
+});
+
+const state = (over: Partial<AutomationState> = {}): AutomationState => ({
+  savings: { 'sav-1': 10_000 },
+  scalars: { bufferAccount: 20_000, portfolio: 656_009, bsu: 50_000, pensionOtp: 300_000, pensionIps: 100_000 },
+  mortgage: 2_000_000,
+  mortgageRate: 5,
+  debts: { 'd-1': { balance: 200_000, rate: 5 } },
+  housingMode: 'homeowner',
+  ...over,
+});
+
+const rule = (over: Partial<AutomationRule> = {}): AutomationRule => ({
+  id: 'r-1',
+  name: 'Aksjer og fond',
+  amount: 1_383,
+  targetKind: 'portfolio',
+  startMonth: '2026-09',
+  lastPostedMonth: NOW,
+  ...over,
+});
+
+describe('monthsAhead', () => {
+  it('counts whole months forward', () => {
+    expect(monthsAhead('2026-08', '2026-09')).toBe(1);
+    expect(monthsAhead('2026-08', '2026-12')).toBe(4);
+    expect(monthsAhead('2026-08', '2027-08')).toBe(12);
+  });
+
+  it('is 0 for the same or an earlier month', () => {
+    expect(monthsAhead('2026-08', '2026-08')).toBe(0);
+    expect(monthsAhead('2026-08', '2026-07')).toBe(0);
+  });
+});
+
+describe('projectSnapshotBalances — contributions only', () => {
+  it('adds one month of the rule to its destination', () => {
+    // The reported case: 656 009 + one 1 383 kr transfer.
+    const out = projectSnapshotBalances(base(), [rule()], state(), '2026-09', NOW);
+    expect(out.portfolio).toBe(657_392);
+  });
+
+  it('scales with the distance travelled', () => {
+    const out = projectSnapshotBalances(base(), [rule()], state(), '2026-12', NOW);
+    expect(out.portfolio).toBe(656_009 + 1_383 * 4);
+  });
+
+  it('leaves untouched buckets exactly alone', () => {
+    const out = projectSnapshotBalances(base(), [rule()], state(), '2027-08', NOW);
+    expect(out.crypto).toBe(5_000);
+    expect(out.houseValue).toBe(4_000_000);
+    expect(out.bsu).toBe(50_000);
+    expect(out.bufferAccount).toBe(20_000);
+  });
+
+  it('routes each target kind to the right field', () => {
+    const rules = [
+      rule({ id: 'a', targetKind: 'savingsAccount', savingsAccountId: 'sav-1', amount: 500 }),
+      rule({ id: 'b', targetKind: 'bufferAccount', amount: 500 }),
+      rule({ id: 'c', targetKind: 'bsu', amount: 100 }),
+      rule({ id: 'd', targetKind: 'pensionOtp', amount: 2_000 }),
+      rule({ id: 'e', targetKind: 'pensionIps', amount: 1_000 }),
+    ];
+    const out = projectSnapshotBalances(base(), rules, state(), '2026-10', NOW);
+    expect(out.savingsAccounts[0].balance).toBe(10_000 + 500 * 2);
+    expect(out.bufferAccount).toBe(20_000 + 500 * 2);
+    expect(out.bsu).toBe(50_000 + 100 * 2);
+    expect(out.otpBalance).toBe(300_000 + 2_000 * 2);
+    expect(out.ipsBalance).toBe(100_000 + 1_000 * 2);
+  });
+
+  it('amortizes a mortgage payment down rather than adding it up', () => {
+    const out = projectSnapshotBalances(
+      base(), [rule({ targetKind: 'mortgage', amount: 20_000 })], state(), '2026-09', NOW);
+    expect(out.houseDebt).toBeLessThan(2_000_000);
+    // One month's interest at 5%/yr on 2M is ~8 333, so ~11 667 comes off.
+    expect(out.houseDebt).toBeGreaterThan(2_000_000 - 20_000);
+  });
+
+  it('amortizes an extra debt payment', () => {
+    const out = projectSnapshotBalances(
+      base(), [rule({ targetKind: 'debt', debtId: 'd-1', amount: 5_000 })], state(), '2026-09', NOW);
+    expect(out.debts[0].balance).toBeLessThan(200_000);
+  });
+
+  it('stacks two rules pointed at the same destination', () => {
+    const rules = [rule({ id: 'a', amount: 1_000 }), rule({ id: 'b', amount: 500 })];
+    const out = projectSnapshotBalances(base(), rules, state(), '2026-09', NOW);
+    expect(out.portfolio).toBe(656_009 + 1_500);
+  });
+
+  it('returns the base unchanged for the current or a past month', () => {
+    expect(projectSnapshotBalances(base(), [rule()], state(), NOW, NOW).portfolio).toBe(656_009);
+    expect(projectSnapshotBalances(base(), [rule()], state(), '2026-07', NOW).portfolio).toBe(656_009);
+  });
+
+  it('is a no-op with no rules', () => {
+    expect(projectSnapshotBalances(base(), [], state(), '2027-08', NOW)).toEqual(base());
+  });
+
+  it('skips a rule whose destination no longer exists', () => {
+    const out = projectSnapshotBalances(
+      base(), [rule({ targetKind: 'savingsAccount', savingsAccountId: 'gone' })], state(), '2026-09', NOW);
+    expect(out.savingsAccounts[0].balance).toBe(10_000);
+  });
+});
+
+describe('projectSnapshotBalances — with assumed growth', () => {
+  const rates: ProjectionRates = { portfolio: 7, cash: 1, crypto: 0, house: 3 };
+
+  it('compounds growth on the opening balance on top of the contributions', () => {
+    const out = projectSnapshotBalances(base(), [rule()], state(), '2027-08', NOW, rates);
+    const contributions = 1_383 * 12;
+    const grown = 656_009 * 1.07;
+    expect(out.portfolio).toBe(Math.round(grown + contributions));
+  });
+
+  it('grows buckets that no rule touches', () => {
+    const out = projectSnapshotBalances(base(), [], state(), '2027-08', NOW, rates);
+    expect(out.houseValue).toBe(Math.round(4_000_000 * 1.03));
+    expect(out.bufferAccount).toBe(Math.round(20_000 * 1.01));
+    expect(out.savingsAccounts[0].balance).toBe(Math.round(10_000 * 1.01));
+  });
+
+  it('never grows a debt — its interest is already in the amortization', () => {
+    const out = projectSnapshotBalances(base(), [], state(), '2027-08', NOW, rates);
+    expect(out.debts[0].balance).toBe(200_000);
+    expect(out.houseDebt).toBe(2_000_000);
+  });
+
+  it('is identical to contributions-only at a 0% rate', () => {
+    const zero: ProjectionRates = { portfolio: 0, cash: 0, crypto: 0, house: 0 };
+    expect(projectSnapshotBalances(base(), [rule()], state(), '2026-12', NOW, zero))
+      .toEqual(projectSnapshotBalances(base(), [rule()], state(), '2026-12', NOW));
+  });
+
+  it('yields a strictly larger portfolio than contributions-only', () => {
+    const withGrowth = projectSnapshotBalances(base(), [rule()], state(), '2027-08', NOW, rates);
+    const without = projectSnapshotBalances(base(), [rule()], state(), '2027-08', NOW);
+    expect(withGrowth.portfolio).toBeGreaterThan(without.portfolio);
+  });
+});
+
+describe('projectSnapshotBalances — purity', () => {
+  it('never mutates the base balances', () => {
+    const input = base();
+    const before = JSON.parse(JSON.stringify(input));
+    projectSnapshotBalances(input, [rule()], state(), '2027-08', NOW, { portfolio: 7, cash: 1, crypto: 0, house: 3 });
+    expect(input).toEqual(before);
+  });
+
+  it('never mutates the automation state', () => {
+    const s = state();
+    const before = JSON.parse(JSON.stringify(s));
+    projectSnapshotBalances(base(), [rule()], s, '2027-08', NOW);
+    expect(s).toEqual(before);
+  });
+
+  it('returns fresh nested objects, so edits cannot leak back into live state', () => {
+    const input = base();
+    const out = projectSnapshotBalances(input, [rule()], state(), '2026-09', NOW);
+    expect(out.savingsAccounts[0]).not.toBe(input.savingsAccounts[0]);
+    expect(out.debts[0]).not.toBe(input.debts[0]);
+  });
+
+  it('is deterministic — same inputs, same output', () => {
+    const a = projectSnapshotBalances(base(), [rule()], state(), '2027-02', NOW);
+    const b = projectSnapshotBalances(base(), [rule()], state(), '2027-02', NOW);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/lib/projectBalances.ts
+++ b/src/lib/projectBalances.ts
@@ -1,0 +1,119 @@
+// Growing today's balances forward into a month that has not happened yet.
+//
+// The balance pages can render any past month from a captured snapshot. A future
+// month has nothing to read, so this module *computes* one: it takes the live
+// balances and runs the automation that has not fired yet.
+//
+// It never writes. The projection is assembled in the view layer and thrown away
+// on the next render; the three code paths that persist anything — the snapshot
+// capture, the automation rule set, and the runner effect — all read the real
+// clock via `currentMonthKey()`, so a projected month is invisible to them.
+import { computeAutomationPostings, type AutomationRule, type AutomationState } from './automation';
+import { monthsBetween } from './date';
+import type { SnapshotBalances } from './snapshots';
+
+/**
+ * Annual growth percentages, one per bucket that can grow on its own. Supplying
+ * these switches the projection from "only the transfers you set up" to "those
+ * transfers plus assumed market growth" — the toggle on a projected month.
+ */
+export interface ProjectionRates {
+  /** Investment portfolio. */
+  portfolio: number;
+  /** Savings accounts, buffer and BSU. */
+  cash: number;
+  crypto: number;
+  house: number;
+}
+
+/** Whole months from `fromMonth` to `toMonth`; 0 when `toMonth` is not later. */
+export function monthsAhead(fromMonth: string, toMonth: string): number {
+  return toMonth > fromMonth ? monthsBetween(fromMonth, toMonth).length - 1 : 0;
+}
+
+/** Compound `annualPct` over `months`, as a multiplier. A non-finite or
+ *  non-positive rate leaves the balance alone rather than poisoning it. */
+function growth(annualPct: number, months: number): number {
+  if (!Number.isFinite(annualPct) || annualPct <= 0 || months <= 0) return 1;
+  return (1 + annualPct / 100) ** (months / 12);
+}
+
+/**
+ * Project `base` forward to `targetMonth`.
+ *
+ * Contributions come from `computeAutomationPostings`, which is already pure and
+ * already takes the month as a parameter: handed a future key it reports what
+ * each rule will have moved by then, mortgage and debt amortization included.
+ * So the arithmetic here is only the folding, plus optional growth.
+ *
+ * When `rates` is given, growth compounds on the balance held TODAY and the new
+ * contributions are added at face value. That understates the result slightly,
+ * which is the honest direction to be wrong in, and it keeps the growth figure
+ * explainable as "what today's money earns" rather than a blended number nobody
+ * can reproduce by hand. Debts never grow here — `applyAmortization` has already
+ * charged their interest inside the posting.
+ */
+export function projectSnapshotBalances(
+  base: SnapshotBalances,
+  rules: AutomationRule[],
+  state: AutomationState,
+  targetMonth: string,
+  nowMonth: string,
+  rates?: ProjectionRates,
+): SnapshotBalances {
+  const months = monthsAhead(nowMonth, targetMonth);
+  // Deep-copy every mutable slice: the caller's `base` is live app state, and a
+  // projection that scribbled on it would corrupt the very balances it grew from.
+  const out: SnapshotBalances = {
+    ...base,
+    savingsAccounts: base.savingsAccounts.map(s => ({ ...s })),
+    debts: base.debts.map(d => ({ ...d })),
+  };
+  if (months <= 0) return out;
+
+  for (const p of computeAutomationPostings(rules, state, targetMonth)) {
+    if (p.targetKind === 'savingsAccount') {
+      const acc = out.savingsAccounts.find(s => s.id === p.savingsAccountId);
+      if (acc) acc.balance = p.newBalance;
+    } else if (p.targetKind === 'debt') {
+      const debt = out.debts.find(d => d.id === p.debtId);
+      if (debt) debt.balance = p.newBalance;
+    } else if (p.targetKind === 'mortgage') {
+      out.houseDebt = p.newBalance;
+    } else if (p.targetKind === 'pensionOtp') {
+      out.otpBalance = p.newBalance;
+    } else if (p.targetKind === 'pensionIps') {
+      out.ipsBalance = p.newBalance;
+    } else {
+      // bufferAccount | portfolio | bsu — same name in both shapes.
+      out[p.targetKind] = p.newBalance;
+    }
+  }
+
+  if (rates) {
+    const cash = growth(rates.cash, months);
+    // Growth is earned on the opening balance, so it is computed from `base`
+    // rather than from the already-contributed figure in `out`.
+    out.portfolio += base.portfolio * (growth(rates.portfolio, months) - 1);
+    out.crypto += base.crypto * (growth(rates.crypto, months) - 1);
+    out.houseValue += base.houseValue * (growth(rates.house, months) - 1);
+    out.bufferAccount += base.bufferAccount * (cash - 1);
+    out.bsu += base.bsu * (cash - 1);
+    out.savingsAccounts.forEach((acc, i) => {
+      acc.balance += (base.savingsAccounts[i]?.balance ?? 0) * (cash - 1);
+    });
+  }
+
+  // Whole kroner throughout, matching what the automation runner would store.
+  out.portfolio = Math.round(out.portfolio);
+  out.crypto = Math.round(out.crypto);
+  out.houseValue = Math.round(out.houseValue);
+  out.houseDebt = Math.round(out.houseDebt);
+  out.bufferAccount = Math.round(out.bufferAccount);
+  out.bsu = Math.round(out.bsu);
+  out.otpBalance = Math.round(out.otpBalance);
+  out.ipsBalance = Math.round(out.ipsBalance);
+  out.savingsAccounts.forEach(acc => { acc.balance = Math.round(acc.balance); });
+  out.debts.forEach(d => { d.balance = Math.round(d.balance); });
+  return out;
+}

--- a/src/lib/snapshots.test.ts
+++ b/src/lib/snapshots.test.ts
@@ -1,49 +1,55 @@
 import { describe, it, expect } from 'vitest';
-import { nearestSnapshot, historyRows, buildManualSnapshot, snapToRecordedMonth, type SnapshotBalances } from './snapshots';
+import { nearestSnapshot, historyRows, buildManualSnapshot, resolveMonthView, type SnapshotBalances } from './snapshots';
 import { netWorthFromSnapshot } from './netWorth';
 import type { BalanceSnapshot } from '../context/FinanceContext';
 
 const mk = (source: 'auto' | 'manual' = 'auto'): BalanceSnapshot =>
   ({ source, assets: {} } as unknown as BalanceSnapshot);
 
-describe('snapToRecordedMonth', () => {
+describe('resolveMonthView', () => {
   const recorded = ['2026-01', '2026-03', '2026-06'];
   const now = '2026-07';
 
   it('treats the current month as live', () => {
-    expect(snapToRecordedMonth(recorded, now, now)).toEqual({ activeKey: now, isLive: true });
+    expect(resolveMonthView(recorded, now, now)).toEqual({ activeKey: now, mode: 'live' });
   });
 
-  it('treats a future month as live (no future balances to protect)', () => {
-    expect(snapToRecordedMonth(recorded, '2026-09', now)).toEqual({ activeKey: now, isLive: true });
+  it('treats a future month as projected, keeping the picked month', () => {
+    // Not 'live': a future month used to resolve to today's balances, which left
+    // the page editable under next month's label.
+    expect(resolveMonthView(recorded, '2026-09', now)).toEqual({ activeKey: '2026-09', mode: 'projected' });
+  });
+
+  it('projects a future month even with nothing recorded', () => {
+    expect(resolveMonthView([], '2026-08', now)).toEqual({ activeKey: '2026-08', mode: 'projected' });
   });
 
   it('snaps a past month with an exact snapshot to itself, read-only', () => {
-    expect(snapToRecordedMonth(recorded, '2026-03', now)).toEqual({ activeKey: '2026-03', isLive: false });
+    expect(resolveMonthView(recorded, '2026-03', now)).toEqual({ activeKey: '2026-03', mode: 'recorded' });
   });
 
   it('snaps a past gap month to the latest recorded month at or before it', () => {
-    expect(snapToRecordedMonth(recorded, '2026-05', now)).toEqual({ activeKey: '2026-03', isLive: false });
+    expect(resolveMonthView(recorded, '2026-05', now)).toEqual({ activeKey: '2026-03', mode: 'recorded' });
   });
 
   it('falls back to the earliest recorded month when nothing is that early', () => {
-    expect(snapToRecordedMonth(recorded, '2025-11', now)).toEqual({ activeKey: '2026-01', isLive: false });
+    expect(resolveMonthView(recorded, '2025-11', now)).toEqual({ activeKey: '2026-01', mode: 'recorded' });
   });
 
   it('degrades to live when nothing is recorded (a past view can only show live)', () => {
-    expect(snapToRecordedMonth([], '2026-03', now)).toEqual({ activeKey: now, isLive: true });
+    expect(resolveMonthView([], '2026-03', now)).toEqual({ activeKey: now, mode: 'live' });
   });
 
   it('treats snapping to the current month as live, not read-only history', () => {
     // Only the current month has a snapshot (the common case): viewing an earlier
     // month has nothing older to show, so it degrades to live rather than showing
     // today's data read-only under a past label.
-    expect(snapToRecordedMonth([now], '2026-03', now)).toEqual({ activeKey: now, isLive: true });
+    expect(resolveMonthView([now], '2026-03', now)).toEqual({ activeKey: now, mode: 'live' });
   });
 
   it('does not assume the input array is sorted', () => {
-    expect(snapToRecordedMonth(['2026-06', '2026-01', '2026-03'], '2026-04', now))
-      .toEqual({ activeKey: '2026-03', isLive: false });
+    expect(resolveMonthView(['2026-06', '2026-01', '2026-03'], '2026-04', now))
+      .toEqual({ activeKey: '2026-03', mode: 'recorded' });
   });
 });
 

--- a/src/lib/snapshots.ts
+++ b/src/lib/snapshots.ts
@@ -21,31 +21,45 @@ export function nearestSnapshot(
 }
 
 /**
- * Map the single shared month to the balance snapshot a balance page should show.
- * The whole app tracks one freely-picked month; balance pages can't render a month
- * that was never recorded, so:
- *   - current or future month → live (editable current state).
+ * How the picked month relates to reality:
+ *   'live'      — today. Real balances, editable.
+ *   'recorded'  — a past month, read back from a captured snapshot.
+ *   'projected' — a future month, computed from today's balances plus the
+ *                 automation that has not run yet. Never stored, never editable.
+ */
+export type MonthMode = 'live' | 'recorded' | 'projected';
+
+/**
+ * How far ahead a balance page will project. Beyond this the picker stops
+ * stepping: the projection holds income at today's figure, so a balance five
+ * years out would read as precision it does not have.
+ */
+export const PROJECTION_HORIZON_MONTHS = 24;
+
+/**
+ * Map the single shared month to what a balance page should show.
+ * The whole app tracks one freely-picked month, and a balance page can only
+ * render a month it can account for:
+ *   - future month → 'projected'; the caller computes it from live state.
+ *   - current month → 'live' (editable current state).
  *   - past month → the latest recorded snapshot at or before it, else the earliest
  *     recorded month, so we never land on an empty month.
- * `isLive` is derived from the *resolved* month, not the picked one: if we snapped
+ * The mode is derived from the *resolved* month, not the picked one: if we snapped
  * to the current month (because nothing older exists — e.g. only this month has been
  * captured, the common case), the page is live and editable, never today's data
  * shown read-only under a past label.
  */
-export function snapToRecordedMonth(
+export function resolveMonthView(
   recordedKeys: string[],
   viewKey: string,
   nowKey: string,
-): { activeKey: string; isLive: boolean } {
-  const resolve = (): string => {
-    if (viewKey >= nowKey) return nowKey;
-    const sorted = [...recordedKeys].sort();
-    const atOrBefore = sorted.filter(k => k <= viewKey);
-    if (atOrBefore.length) return atOrBefore[atOrBefore.length - 1];
-    return sorted[0] ?? nowKey;
-  };
-  const activeKey = resolve();
-  return { activeKey, isLive: activeKey === nowKey };
+): { activeKey: string; mode: MonthMode } {
+  if (viewKey > nowKey) return { activeKey: viewKey, mode: 'projected' };
+  if (viewKey === nowKey) return { activeKey: nowKey, mode: 'live' };
+  const sorted = [...recordedKeys].sort();
+  const atOrBefore = sorted.filter(k => k <= viewKey);
+  const activeKey = atOrBefore.length ? atOrBefore[atOrBefore.length - 1] : (sorted[0] ?? nowKey);
+  return { activeKey, mode: activeKey === nowKey ? 'live' : 'recorded' };
 }
 
 /** The balances a person can realistically reconstruct for a past month. */
@@ -61,6 +75,31 @@ export interface SnapshotBalances {
   otpBalance: number;
   ipsBalance: number;
   assumptions?: { savingsTargetPercent: number; growthReturnRate: number; houseGrowthRate: number };
+}
+
+/**
+ * Read the balances back out of a snapshot. Used both to seed the manual-backfill
+ * editor and as the starting point a forward projection grows from, so the two
+ * always agree on which fields count as "a balance".
+ */
+export function snapshotBalances(
+  base: BalanceSnapshot,
+  fallbackAssumptions: { savingsTargetPercent: number; growthReturnRate: number; houseGrowthRate: number },
+): SnapshotBalances {
+  const a = base.assets;
+  return {
+    savingsAccounts: (a.savingsAccounts ?? []).map(s => ({ ...s })),
+    bsu: a.bsu ?? 0,
+    bufferAccount: a.bufferAccount ?? 0,
+    portfolio: a.portfolio ?? 0,
+    crypto: a.crypto ?? 0,
+    houseValue: a.houseValue ?? 0,
+    houseDebt: a.houseDebt ?? 0,
+    debts: (base.debts ?? []).map(d => ({ ...d })),
+    otpBalance: base.pension?.otpBalance ?? 0,
+    ipsBalance: base.pension?.ipsBalance ?? 0,
+    assumptions: base.assumptions ?? fallbackAssumptions,
+  };
 }
 
 /**


### PR DESCRIPTION
## The bug

Stepping the month picker forward on `/assets`, `/bolig` or `/pension` showed **today's** balances under a future label. One line was responsible:

```
snapshots.ts:41   if (viewKey >= nowKey) return nowKey;   // → isLive: true
```

Every future month collapsed onto the current one and was reported as live. Two consequences: no projection, and the page stayed **editable** — a pencil tap on "sep. 2026" wrote today's data.

## The fix

`resolveMonthView` replaces `snapToRecordedMonth` with three modes — `recorded` / `live` / `projected`. `isLive` stays `mode === 'live'`, so every existing read-only gate and `?? live` fallback keeps working and the edit bug closes as a side effect.

`computeAutomationPostings` (`automation.ts:104`) was already pure and already month-parameterised, so no new financial math was needed: handed a future key it reports what each rule will have moved by then, mortgage and debt amortization included. The new `projectSnapshotBalances` folds that into a `SnapshotBalances`, and feeding it through the existing `buildManualSnapshot` means all three pages render it via the `snapshot ?? live` path they already had — no per-page value plumbing.

**Contributions only by default**; a header toggle adds assumed growth. Growth compounds on the opening balance with new contributions at face value — conservative, and reproducible by hand. Debts never grow; their interest is already inside the amortization.

**Capped at 24 months.** The projection holds income at today's figure, so it stops being meaningful well before it stops being computable. The stepper and the `?m=` parameter both clamp, which avoids inventing a fourth "too far ahead" state for every page to render.

## Nothing persists

The projected snapshot is assembled per render and never reaches `balanceSnapshots`. The capture effect (`:2140`), the rule set (`:2320`) and the runner (`:2435`) all read the real clock, so the picked month is invisible to them.

Proven empirically, not asserted: against a seeded throwaway DB, 36 month-steps through projections plus a growth toggle left `X-Data-Rev` at **2** and the payload hash **byte-identical**.

## Verification

| Check | Result |
|---|---|
| One month forward | 285 000 + 1 135 = 286 135 |
| Four months, contributions only | +4 × 1 135 = 4 540 |
| Growth on, 4 months | +6 501 = 285 000 × (1.07^⅓ − 1) |
| Growth on, 18 months | 531 272 = 480 000 × 1.07^1.5 |
| Horizon | stops at aug. 2028; button disabled with explanation |
| `?m=2099-01` | clamped to `2028-08` |
| Forward then back | returns to the opening figure exactly |
| Projected month | `pointer-events: none` on all three pages |

`npx tsc -b && npm run lint && npm test` — 1076 tests across 84 files, 39 new (21 projection incl. purity and determinism, 10 month-resolution). Zero console errors.

## Incidental cleanup

Two duplications removed rather than tripled: `balancesFrom` moves out of `HistoryManagerModal` into `snapshots.ts` as `snapshotBalances`, and the live-snapshot object becomes one `liveBalanceSnapshot` memo shared by the capture effect and the projection.

## Note

The growth toggle is view state like `currentMonth`, so it resets each session — persisting it would mean touching the payload in the five places `CLAUDE.md` warns about.