### PR TITLE
refactor: drop the now-unused hasHistory from useBalanceHistory

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -714,3 +714,30 @@ rather than changing the math. **What would unblock**: a decision on which quant
 should mean. **Where**: `src/components/SavingsAllocationPanel.tsx` (the `plan` memo),
 `src/lib/savingsAllocation.ts` (`resolveAllocation`), `src/i18n/translations.ts`
 (`savingsAllocation.*`).
+
+## Projected months — the debt card and the growth toggle
+
+Shipped (2026-08): balance pages resolve a future month as a *projection* instead of collapsing
+it onto today. `resolveMonthView` (`src/lib/snapshots.ts`) returns `recorded` / `live` /
+`projected`; `projectSnapshotBalances` (`src/lib/projectBalances.ts`) grows today's balances with
+`computeAutomationPostings` and optional per-bucket growth, and the result is rendered through the
+existing `snapshot ?? live` path on Formue, Bolig and Pensjon. Capped at 24 months, read-only,
+never persisted.
+
+Remaining 1 — **`DebtSection` is hidden on any non-live month.** Debt balances *are* projected
+(amortization runs, and the net-worth totals on the page already reflect it), but the card itself
+is gated out at `src/pages/AssetPage.tsx:641` (`hist.isLive && <DebtSection />`). It cannot simply
+be un-gated: `DebtSection` reads `debts` straight from `useFinance()` (`src/components/DebtSection.tsx:33`),
+so showing it on a projected month would render *live* balances under a projected label — the exact
+bug the projection work fixed elsewhere. **What would unblock**: take the resolved rows as a prop
+(AssetPage already computes them at `:106`) and give the section a read-only mode, so the same card
+serves live, recorded and projected months. Worth doing — watching a debt fall is one of the more
+motivating things to project. **Where**: `src/components/DebtSection.tsx`, `src/pages/AssetPage.tsx:106,641`.
+
+Remaining 2 — **the "with growth" toggle resets every session.** `projectionIncludeGrowth` is view
+state next to `currentMonth` (`src/context/FinanceContext.tsx`), deliberately not persisted, so the
+projection always opens on the reproducible contributions-only view. Persisting it means adding the
+field to every site the persist/export payload is hand-maintained in (autosave payload + dep array,
+`applyData`, `importAll`, demo snapshot, `SettingsPage` export) — see the warning in `CLAUDE.md`.
+**What would unblock**: a decision that the preference is worth that surface area.
+**Where**: `src/context/FinanceContext.tsx`, `src/components/Layout.tsx` (the toggle).

--- a/src/hooks/useBalanceHistory.ts
+++ b/src/hooks/useBalanceHistory.ts
@@ -19,8 +19,6 @@ export interface BalanceHistory {
   isProjected: boolean;
   /** The snapshot for the active month: recorded, projected, or null when live. */
   snapshot: BalanceSnapshot | null;
-  /** True when there's at least one recorded snapshot to travel to. */
-  hasHistory: boolean;
 }
 
 /**
@@ -77,16 +75,11 @@ export function useBalanceHistory(): BalanceHistory {
   }, [mode, liveBalanceSnapshot, automationRules, automationState, activeKey, nowKey, rates,
       savingsTargetPercent, growthReturnRate, houseGrowthRate]);
 
-  // "Has history" counts recorded months other than the live one — that's what
-  // makes the time machine worth showing.
-  const hasHistory = recordedKeys.some(k => k !== nowKey);
-
   return {
     activeKey,
     mode,
     isLive: mode === 'live',
     isProjected: mode === 'projected',
     snapshot: mode === 'live' ? null : mode === 'projected' ? projected : balanceSnapshots[activeKey] ?? null,
-    hasHistory,
   };
 }


### PR DESCRIPTION
Follow-up to #123.

**Dead code.** Balance pages show the month picker unconditionally now that they project forward, so `showPicker` no longer consults `hasHistory` — and nothing else did. It was still being computed and exported. Removed.

**Backlog.** Records two known gaps from the projection work:

1. `DebtSection` is hidden on any non-live month (`AssetPage.tsx:641`). Debt balances *are* projected — amortization runs and the page's net-worth totals already reflect it — but the card can't simply be un-gated: it reads `debts` straight from `useFinance()` (`DebtSection.tsx:33`), so it would render live balances under a projected label, the exact bug #123 fixed elsewhere. Unblocking it means taking the resolved rows as a prop (AssetPage computes them at `:106`) and adding a read-only mode.
2. The "with growth" toggle is view state beside `currentMonth`, so it resets each session. Persisting it means touching the five hand-maintained payload sites `CLAUDE.md` warns about.

## Verification of #123 completed

I'd claimed all three balance pages behaved correctly but had only checked that Bolig and Pensjon were *gated*, not that their figures moved. The seeded dataset turned out to have no automation rules at all (no pension auto-post, no destination-bearing expenses, `housingMode: first_buyer`), so that run only exercised the growth path. Re-tested against a payload that drives every target kind:

| Page | Projected 6 months | Check |
|---|---|---|
| Formue — portfolio | 480 000 → 498 000 | +6 × 3 000 |
| Formue — IPS | 100 000 → 107 500 | +6 × 15 000/12 |
| Formue — OTP | 300 000 → 319 875 | 5% employer on pensionable income |
| Bolig — mortgage | 3 400 000 → 3 375 766 | matches amortization by hand at 5,65%/yr, 20 000/mo |

`npx tsc -b && npm run lint && npm test` — 1076 tests across 84 files.