### PR TITLE
fix: print the backup path that was actually written

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,11 @@ restart:
 # The only automatic safety net besides the manual JSON export in the UI.
 backup:
 	@mkdir -p backups
-	@docker cp headroom:/data/database.sqlite backups/headroom-$$(date +%Y%m%d-%H%M%S).sqlite
-	@echo ""
-	@echo "  Backed up to backups/headroom-$$(date +%Y%m%d-%H%M%S).sqlite"
-	@echo ""
+	@ts=$$(date +%Y%m%d-%H%M%S) && \
+	  docker cp headroom:/data/database.sqlite backups/headroom-$$ts.sqlite && \
+	  echo "" && \
+	  echo "  Backed up to backups/headroom-$$ts.sqlite" && \
+	  echo ""
 
 # Tail container logs
 logs:


### PR DESCRIPTION
The `backup:` recipe called `date` twice — once to name the file in the `docker cp` line, once to report it in the `echo` line. Those are separate recipe lines, so separate shells, and `docker cp` takes long enough that the two calls regularly land on different seconds. The path printed to the terminal then does not exist on disk. This is the safety net I run by hand before a risky update, so being told the wrong filename is exactly the wrong moment to be confused.

## What changed

`ts` is computed once and reused for both the copy and the message, with the whole thing in a single recipe line so the two share a shell.

Chained with `&&` rather than `;` on purpose: previously a failing `docker cp` aborted the recipe and never reached the echo. Joining with `;` would have regressed that into reporting a success that never happened.

## How I verified it

I did not run `make backup` here, since it copies out of the live data volume. Instead I reproduced both recipes in a temp dir with `docker cp` replaced by a stub that names its file first and then takes time, mirroring the real command:

- old recipe: 9 of 12 runs printed a path that does not exist (e.g. printed `...-141703.sqlite`, disk had `...-141702.sqlite`) — the reported symptom.
- new recipe: 0 of 12.

I also confirmed that a failing copy still aborts with no success line printed, and that `make -n backup` expands as intended.

`npx tsc -b && npm run lint && npm test` pass (88 files, 1136 tests).

Closes #140