### PR TITLE
Add unit tests for small untested src/lib helpers

### DIFF
--- a/src/lib/account.test.ts
+++ b/src/lib/account.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { accountGroupLabel, accountGroupKey } from './account';
+import type { DailyTransaction } from '../context/FinanceContext';
+
+function tx(overrides: Partial<DailyTransaction>): DailyTransaction {
+  return { id: '1', date: '2026-01-01', description: 'x', amount: -100, ...overrides };
+}
+
+describe('accountGroupLabel', () => {
+  it('prefers the custom label, then the account name, then the bank', () => {
+    expect(accountGroupLabel(tx({ account: 'acc1', accountName: 'Brukskonto', bank: 'DNB' }), { acc1: 'My Account' }))
+      .toBe('My Account');
+    expect(accountGroupLabel(tx({ account: 'acc1', accountName: 'Brukskonto', bank: 'DNB' }), {}))
+      .toBe('Brukskonto');
+    expect(accountGroupLabel(tx({ account: 'acc1', bank: 'DNB' }), {}))
+      .toBe('DNB');
+  });
+
+  it('returns null for manual rows with no connected account', () => {
+    expect(accountGroupLabel(tx({}), { acc1: 'My Account' })).toBeNull();
+  });
+});
+
+describe('accountGroupKey', () => {
+  it('groups by custom label when set, else by the account id', () => {
+    expect(accountGroupKey(tx({ account: 'acc1' }), { acc1: 'Shared Label' })).toBe('Shared Label');
+    expect(accountGroupKey(tx({ account: 'acc1' }), {})).toBe('acc1');
+    expect(accountGroupKey(tx({ account: 'acc2' }), { acc1: 'Shared Label' })).toBe('acc2');
+  });
+
+  it('returns null for manual rows with no connected account', () => {
+    expect(accountGroupKey(tx({}), {})).toBeNull();
+  });
+});

--- a/src/lib/accountColor.test.ts
+++ b/src/lib/accountColor.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { accountToken } from './accountColor';
+
+describe('accountToken', () => {
+  it('maps the same key to the same token every time', () => {
+    const token = accountToken('acc-12345');
+    for (let i = 0; i < 5; i++) expect(accountToken('acc-12345')).toBe(token);
+  });
+
+  it('returns one of the chart palette tokens', () => {
+    expect(accountToken('another-account')).toMatch(/^--chart-[1-6]$/);
+  });
+});

--- a/src/lib/categories.test.ts
+++ b/src/lib/categories.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { categoryMeta } from './categories';
+
+describe('categoryMeta', () => {
+  it('returns metadata for a canonical key', () => {
+    expect(categoryMeta('groceries')).toMatchObject({ key: 'groceries', color: '#1F5A42' });
+  });
+
+  it('returns undefined for legacy/custom free-text and for undefined', () => {
+    expect(categoryMeta('some legacy label')).toBeUndefined();
+    expect(categoryMeta(undefined)).toBeUndefined();
+  });
+});

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { birthYearFrom } from './profile';
+
+describe('birthYearFrom', () => {
+  it('parses the four-digit year from a YYYY-MM-DD string', () => {
+    expect(birthYearFrom('1990-05-12')).toBe(1990);
+  });
+
+  it('returns 0 when absent, invalid, or at/before 1900', () => {
+    expect(birthYearFrom(undefined)).toBe(0);
+    expect(birthYearFrom('not-a-date')).toBe(0);
+    expect(birthYearFrom('1900-01-01')).toBe(0);
+  });
+});

--- a/src/lib/provenance.test.ts
+++ b/src/lib/provenance.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { provenanceOf } from './provenance';
+
+describe('provenanceOf', () => {
+  it('is "default" when the value equals the default', () => {
+    expect(provenanceOf(5, 5)).toBe('default');
+  });
+
+  it('is "custom" when the value differs from the default', () => {
+    expect(provenanceOf(5, 4)).toBe('custom');
+  });
+});


### PR DESCRIPTION
Why: CLAUDE.md requires unit tests for pure calculation logic in src/lib, and a handful of small helpers never got one.

What: adds a .test.ts next to each of account.ts, profile.ts, accountColor.ts, and provenance.ts, plus a new categories.test.ts for categoryMeta. Each covers the normal case plus the edge case called out in the file's doc comment: the custom-label -> account-name -> bank fallback chain and the null case for manual rows (account.ts), the invalid/absent/pre-1900 birth year cases (profile.ts), token stability for a repeated key (accountColor.ts), the default/custom comparison (provenance.ts), and the undefined/legacy-string case (categories.ts).

None of these touch the no-go money-math files or FinanceContext's persist shape.

How verified: npx tsc -b && npm run lint && npm test all pass locally (93 test files, 1148 tests, up from 88/1136).

Closes #154